### PR TITLE
feat: Add individual job detail pages and link from careers

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -223,31 +223,31 @@
                 </p>
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                     <!-- Job 1 -->
-                    <a href="#" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="150">
+                    <a href="careers/virtual-assistant.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="150">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">Virtual Assistant</h3>
                         <p class="text-gray-600 text-sm mb-3">Support clients with administrative, technical, or creative assistance remotely.</p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>
                     </a>
                     <!-- Job 2 -->
-                    <a href="#" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="200">
+                    <a href="careers/full-stack-developer.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="200">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">Full-Stack Developer</h3>
                         <p class="text-gray-600 text-sm mb-3">Design, develop, and maintain both front-end and back-end components of web applications.</p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>
                     </a>
                     <!-- Job 3 -->
-                    <a href="#" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="250">
+                    <a href="careers/customer-support-specialist.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="250">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">Customer Support Specialist</h3>
                         <p class="text-gray-600 text-sm mb-3">Provide outstanding customer service and technical support to our clients' customers.</p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>
                     </a>
                     <!-- Job 4 -->
-                    <a href="#" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="300">
+                    <a href="careers/ui-ux-designer.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="300">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">UI/UX Designer</h3>
                         <p class="text-gray-600 text-sm mb-3">Create intuitive, engaging, and visually appealing user interfaces and experiences for web and mobile applications.</p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>
                     </a>
                     <!-- Job 5 -->
-                    <a href="#" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="350">
+                    <a href="careers/business-analyst.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="350">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">Business Analyst</h3>
                         <p class="text-gray-600 text-sm mb-3">Analyze business processes, identify needs, and recommend solutions to improve efficiency and outcomes.</p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>

--- a/careers/business-analyst.html
+++ b/careers/business-analyst.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Business Analyst | Careers | Bridgee Solutions</title>
+  <meta name="description" content="Bridgee Solutions is hiring a Business Analyst in Addis Ababa (Remote Friendly). Analyze business processes, identify needs, and recommend solutions.">
+
+  <!-- Tailwind CSS CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Font Awesome -->
+  <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+  />
+
+  <!-- AOS (Animate on Scroll) -->
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+
+  <!-- Fonts and Custom Styles -->
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
+    body {
+      font-family: 'Poppins', sans-serif;
+      scroll-behavior: smooth;
+    }
+    .hero-gradient {
+      background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%);
+      animation: gradient 15s ease infinite;
+      background-size: 400% 400%;
+    }
+    @keyframes gradient {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+    .cta-button {
+      position: relative;
+      overflow: hidden;
+      z-index: 1;
+    }
+    .cta-button:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 0;
+      height: 100%;
+      background-color: rgba(255,255,255,0.1);
+      z-index: -1;
+      transition: width 0.3s ease;
+    }
+    .cta-button:hover:before {
+      width: 100%;
+    }
+  </style>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "JobPosting",
+      "title": "Business Analyst",
+      "description": "<p>We are seeking an analytical and detail-oriented Business Analyst to identify business needs, analyze processes, and recommend solutions that help our clients achieve their strategic goals. You will bridge the gap between business stakeholders and technical teams.</p>",
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "Bridgee Solutions",
+        "value": "BA-001"
+      },
+      "datePosted": "2024-03-15",
+      "validThrough": "2024-04-15",
+      "employmentType": "FULL_TIME",
+      "hiringOrganization": {
+        "@type": "Organization",
+        "name": "Bridgee Solutions",
+        "sameAs": "https://www.bridgeesolutions.com",
+        "logo": "https://www.bridgeesolutions.com/Solutions.png"
+      },
+      "jobLocation": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Addis Ababa",
+          "addressCountry": "ET"
+        }
+      },
+      "jobLocationType": "TELECOMMUTE",
+      "applicantLocationRequirements": {
+        "@type": "Country",
+        "name": "Ethiopia"
+      }
+    }
+  </script>
+</head>
+
+<body class="bg-gray-50">
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-lg sticky top-0 z-50">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center">
+                <a href="../index.html" class="flex items-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-lg">
+                    <img src="../Solutions.png" alt="Bridgee Solutions Logo" class="h-12 w-auto" />
+                    <span class="ml-2 text-xl font-semibold text-gray-800">Bridgee <span class="text-blue-600">Solutions</span></span>
+                </a>
+                </div>
+
+                <div class="md:flex items-center hidden space-x-8">
+                    <a href="../index.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Home</a>
+                    <a href="../about.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">About Us</a>
+                    <a href="../services.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Services</a>
+                    <a href="../careers.html" class="text-blue-600 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Careers</a>
+                    <a href="../index.html#blog" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Blog</a>
+                    <a href="../contact.html" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+                <div class="md:hidden flex items-center">
+                    <button class="outline-none mobile-menu-button focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md" id="mobile-menu-button" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-menu">
+                        <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div class="mobile-menu hidden md:hidden fixed top-16 left-0 right-0 bg-white/30 backdrop-blur-lg shadow-lg z-50" id="mobile-menu">
+                <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 flex flex-col border-t">
+                    <a href="../index.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Home</a>
+                    <a href="../about.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">About Us</a>
+                    <a href="../services.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Services</a>
+                    <a href="../careers.html" class="px-3 py-2 rounded-md text-sm font-semibold text-blue-600 bg-blue-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Careers</a>
+                    <a href="../index.html#blog" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Blog</a>
+                    <a href="../contact.html" class="px-3 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 block text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <main id="job-detail-content" class="bg-white py-12 md:py-16">
+        <div class="container mx-auto px-6">
+            <div class="mb-8 text-sm" data-aos="fade-right">
+                <a href="../careers.html" class="text-blue-600 hover:text-blue-800 font-semibold transition duration-300 inline-flex items-center">
+                    <i class="fas fa-arrow-left mr-2"></i> Back to All Careers
+                </a>
+            </div>
+
+            <h1 class="text-3xl md:text-4xl font-bold text-blue-700 mb-2" data-aos="fade-up">Business Analyst</h1>
+
+            <p class="text-lg text-gray-600 mb-6" data-aos="fade-up" data-aos-delay="100">
+                Location: Addis Ababa, Ethiopia - Remote Friendly | Job Type: Full-time
+            </p>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="200">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Role Overview</h2>
+                <p class="text-gray-700 leading-relaxed">
+                    We are seeking an analytical and detail-oriented Business Analyst to identify business needs, analyze processes, and recommend solutions that help our clients achieve their strategic goals. You will act as a vital link between business stakeholders and technical teams, ensuring clear communication and effective project outcomes.
+                </p>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Key Responsibilities</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Elicit, analyze, and document business requirements from stakeholders.</li>
+                    <li>Translate business needs into functional and technical specifications.</li>
+                    <li>Develop process models, diagrams, and use cases.</li>
+                    <li>Collaborate with project managers, development teams, and clients to ensure solutions meet business objectives.</li>
+                    <li>Facilitate meetings and workshops for requirements gathering and validation.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="400">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Required Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Bachelor's degree in Business Administration, Information Technology, or a related field.</li>
+                    <li>Proven experience as a Business Analyst or in a similar analytical role.</li>
+                    <li>Strong analytical and problem-solving skills with attention to detail.</li>
+                    <li>Excellent communication, interpersonal, and presentation skills.</li>
+                    <li>Proficiency in requirements gathering, process mapping, and documentation.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="500">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Preferred Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Experience with Agile or Scrum methodologies.</li>
+                    <li>Familiarity with business analysis tools (e.g., JIRA, Confluence, Visio).</li>
+                    <li>CBAP or similar business analysis certification is a plus.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="600">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">What We Offer (Benefits)</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Competitive salary and benefits.</li>
+                    <li>Flexible and remote-friendly work environment.</li>
+                    <li>Opportunities for professional growth and certifications.</li>
+                    <li>Engaging projects with a diverse range of clients.</li>
+                    <li>A supportive culture that values analytical thinking and collaboration.</li>
+                </ul>
+            </section>
+
+            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
+                <p class="text-gray-700 leading-relaxed text-center">
+                    To apply, please send your CV and a cover letter outlining your analytical skills and project experience to
+                    <a href="mailto:careers@bridgeesolutions.com?subject=Business Analyst Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
+                    with the job title "Business Analyst" in the subject line.
+                </p>
+                <p class="text-sm text-gray-600 mt-4 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+                </p>
+            </section>
+
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-12">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-12">
+                <div class="md:col-span-2">
+                    <a href="../index.html" class="flex items-center mb-6 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-lg">
+                    <img src="../Solutions_darkmode.png" alt="Bridgee Solutions Logo" class="h-8 w-auto mr-2">
+                    <span class="text-xl font-semibold">Bridgee <span class="text-blue-400">Solutions</span></span>
+                    </a>
+                    <p class="text-gray-300 mb-4">Your bridge to cost-effective, scalable outsourcing solutions with Ethiopian talent.</p>
+                    <div class="flex space-x-4">
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Facebook"><i class="fab fa-facebook-f"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Twitter"><i class="fab fa-twitter"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Instagram"><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Company</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../about.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">About Us</a></li>
+                        <li><a href="../careers.html" class="text-blue-400 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Careers</a></li>
+                        <li><a href="../index.html#blog" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Blog</a></li>
+                        <li><a href="../contact.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Contact</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Services</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../services.html#virtual-assistance" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Virtual Assistants</a></li>
+                        <li><a href="../services.html#software-development" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Software Development</a></li>
+                        <li><a href="../services.html#bpo-services" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">BPO Services</a></li>
+                        <li><a href="../services.html#custom-solutions" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Custom Solutions</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Legal</h3>
+                    <ul class="space-y-2">
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Privacy Policy</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Terms of Service</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">GDPR Compliance</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 mt-12 pt-8 text-center text-gray-300">
+                <p>© 2024 Bridgee Solutions. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+      const menuButton = document.getElementById('mobile-menu-button');
+      const menu = document.getElementById('mobile-menu');
+
+      menuButton.addEventListener('click', function() {
+        const isExpanded = menuButton.getAttribute('aria-expanded') === 'true' || false;
+        menuButton.setAttribute('aria-expanded', !isExpanded);
+        menu.classList.toggle('hidden');
+        document.body.style.overflow = menu.classList.contains('hidden') ? '' : 'hidden';
+
+        if (!isExpanded && !menu.classList.contains('hidden')) {
+          const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+          if (focusableElements.length > 0) {
+            focusableElements[0].focus();
+          }
+        }
+      });
+
+      menu.addEventListener('keydown', function(event) {
+        if (menu.classList.contains('hidden') || event.key !== 'Tab') return;
+
+        const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+        if (focusableElements.length === 0) return;
+        const firstFocusableElement = focusableElements[0];
+        const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstFocusableElement) {
+            lastFocusableElement.focus();
+            event.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastFocusableElement) {
+            firstFocusableElement.focus();
+            event.preventDefault();
+          }
+        }
+      });
+
+      document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
+          menu.classList.add('hidden');
+          document.body.style.overflow = '';
+          menuButton.setAttribute('aria-expanded', 'false');
+          menuButton.focus();
+        }
+      });
+    </script>
+
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>
+    AOS.init();
+  </script>
+</body>
+</html>

--- a/careers/customer-support-specialist.html
+++ b/careers/customer-support-specialist.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Customer Support Specialist | Careers | Bridgee Solutions</title>
+  <meta name="description" content="Join Bridgee Solutions as a Customer Support Specialist in Addis Ababa (Remote Friendly). Provide exceptional service and support to our clients' customers.">
+
+  <!-- Tailwind CSS CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Font Awesome -->
+  <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+  />
+
+  <!-- AOS (Animate on Scroll) -->
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+
+  <!-- Fonts and Custom Styles -->
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
+    body {
+      font-family: 'Poppins', sans-serif;
+      scroll-behavior: smooth;
+    }
+    .hero-gradient {
+      background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%);
+      animation: gradient 15s ease infinite;
+      background-size: 400% 400%;
+    }
+    @keyframes gradient {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+    .cta-button {
+      position: relative;
+      overflow: hidden;
+      z-index: 1;
+    }
+    .cta-button:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 0;
+      height: 100%;
+      background-color: rgba(255,255,255,0.1);
+      z-index: -1;
+      transition: width 0.3s ease;
+    }
+    .cta-button:hover:before {
+      width: 100%;
+    }
+  </style>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "JobPosting",
+      "title": "Customer Support Specialist",
+      "description": "<p>We are seeking a dedicated Customer Support Specialist to provide outstanding service and technical assistance to our clients' customers. You will be the first point of contact for inquiries, troubleshooting issues, and ensuring customer satisfaction.</p>",
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "Bridgee Solutions",
+        "value": "CSS-001"
+      },
+      "datePosted": "2024-03-15",
+      "validThrough": "2024-04-15",
+      "employmentType": "FULL_TIME",
+      "hiringOrganization": {
+        "@type": "Organization",
+        "name": "Bridgee Solutions",
+        "sameAs": "https://www.bridgeesolutions.com",
+        "logo": "https://www.bridgeesolutions.com/Solutions.png"
+      },
+      "jobLocation": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Addis Ababa",
+          "addressCountry": "ET"
+        }
+      },
+      "jobLocationType": "TELECOMMUTE",
+      "applicantLocationRequirements": {
+        "@type": "Country",
+        "name": "Ethiopia"
+      }
+    }
+  </script>
+</head>
+
+<body class="bg-gray-50">
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-lg sticky top-0 z-50">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center">
+                <a href="../index.html" class="flex items-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-lg">
+                    <img src="../Solutions.png" alt="Bridgee Solutions Logo" class="h-12 w-auto" />
+                    <span class="ml-2 text-xl font-semibold text-gray-800">Bridgee <span class="text-blue-600">Solutions</span></span>
+                </a>
+                </div>
+
+                <div class="md:flex items-center hidden space-x-8">
+                    <a href="../index.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Home</a>
+                    <a href="../about.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">About Us</a>
+                    <a href="../services.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Services</a>
+                    <a href="../careers.html" class="text-blue-600 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Careers</a>
+                    <a href="../index.html#blog" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Blog</a>
+                    <a href="../contact.html" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+                <div class="md:hidden flex items-center">
+                    <button class="outline-none mobile-menu-button focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md" id="mobile-menu-button" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-menu">
+                        <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div class="mobile-menu hidden md:hidden fixed top-16 left-0 right-0 bg-white/30 backdrop-blur-lg shadow-lg z-50" id="mobile-menu">
+                <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 flex flex-col border-t">
+                    <a href="../index.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Home</a>
+                    <a href="../about.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">About Us</a>
+                    <a href="../services.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Services</a>
+                    <a href="../careers.html" class="px-3 py-2 rounded-md text-sm font-semibold text-blue-600 bg-blue-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Careers</a>
+                    <a href="../index.html#blog" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Blog</a>
+                    <a href="../contact.html" class="px-3 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 block text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <main id="job-detail-content" class="bg-white py-12 md:py-16">
+        <div class="container mx-auto px-6">
+            <div class="mb-8 text-sm" data-aos="fade-right">
+                <a href="../careers.html" class="text-blue-600 hover:text-blue-800 font-semibold transition duration-300 inline-flex items-center">
+                    <i class="fas fa-arrow-left mr-2"></i> Back to All Careers
+                </a>
+            </div>
+
+            <h1 class="text-3xl md:text-4xl font-bold text-blue-700 mb-2" data-aos="fade-up">Customer Support Specialist</h1>
+
+            <p class="text-lg text-gray-600 mb-6" data-aos="fade-up" data-aos-delay="100">
+                Location: Addis Ababa, Ethiopia - Remote Friendly | Job Type: Full-time
+            </p>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="200">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Role Overview</h2>
+                <p class="text-gray-700 leading-relaxed">
+                    We are seeking a dedicated and empathetic Customer Support Specialist to provide outstanding service and technical assistance to our clients' customers. You will be the first point of contact for inquiries, troubleshooting issues, and ensuring overall customer satisfaction and loyalty.
+                </p>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Key Responsibilities</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Respond to customer inquiries via email, chat, and phone in a timely and professional manner.</li>
+                    <li>Identify and resolve customer issues, escalating to senior staff when necessary.</li>
+                    <li>Maintain accurate records of customer interactions and transactions.</li>
+                    <li>Provide product information and assistance to customers.</li>
+                    <li>Contribute to team effort by accomplishing related results as needed.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="400">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Required Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Proven customer support experience or experience as a client service representative.</li>
+                    <li>Excellent communication and presentation skills (verbal and written in English).</li>
+                    <li>Strong phone contact handling skills and active listening abilities.</li>
+                    <li>Ability to multi-task, prioritize, and manage time effectively.</li>
+                    <li>Proficiency with CRM systems and practices.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="500">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Preferred Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Experience with help desk software (e.g., Zendesk, Intercom).</li>
+                    <li>Familiarity with e-commerce platforms or SaaS products.</li>
+                    <li>Additional language proficiency is a plus.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="600">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">What We Offer (Benefits)</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>A competitive salary and performance-based incentives.</li>
+                    <li>Flexible work environment, including remote work options.</li>
+                    <li>Comprehensive training and ongoing professional development.</li>
+                    <li>Supportive team culture focused on collaboration and growth.</li>
+                    <li>Opportunity to make a real impact on customer satisfaction.</li>
+                </ul>
+            </section>
+
+            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
+                <p class="text-gray-700 leading-relaxed text-center">
+                    To apply, please send your CV and a cover letter detailing your customer service philosophy to
+                    <a href="mailto:careers@bridgeesolutions.com?subject=Customer Support Specialist Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
+                    with the job title "Customer Support Specialist" in the subject line.
+                </p>
+                <p class="text-sm text-gray-600 mt-4 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+                </p>
+            </section>
+
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-12">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-12">
+                <div class="md:col-span-2">
+                    <a href="../index.html" class="flex items-center mb-6 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-lg">
+                    <img src="../Solutions_darkmode.png" alt="Bridgee Solutions Logo" class="h-8 w-auto mr-2">
+                    <span class="text-xl font-semibold">Bridgee <span class="text-blue-400">Solutions</span></span>
+                    </a>
+                    <p class="text-gray-300 mb-4">Your bridge to cost-effective, scalable outsourcing solutions with Ethiopian talent.</p>
+                    <div class="flex space-x-4">
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Facebook"><i class="fab fa-facebook-f"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Twitter"><i class="fab fa-twitter"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Instagram"><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Company</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../about.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">About Us</a></li>
+                        <li><a href="../careers.html" class="text-blue-400 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Careers</a></li>
+                        <li><a href="../index.html#blog" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Blog</a></li>
+                        <li><a href="../contact.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Contact</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Services</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../services.html#virtual-assistance" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Virtual Assistants</a></li>
+                        <li><a href="../services.html#software-development" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Software Development</a></li>
+                        <li><a href="../services.html#bpo-services" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">BPO Services</a></li>
+                        <li><a href="../services.html#custom-solutions" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Custom Solutions</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Legal</h3>
+                    <ul class="space-y-2">
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Privacy Policy</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Terms of Service</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">GDPR Compliance</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 mt-12 pt-8 text-center text-gray-300">
+                <p>© 2024 Bridgee Solutions. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+      const menuButton = document.getElementById('mobile-menu-button');
+      const menu = document.getElementById('mobile-menu');
+
+      menuButton.addEventListener('click', function() {
+        const isExpanded = menuButton.getAttribute('aria-expanded') === 'true' || false;
+        menuButton.setAttribute('aria-expanded', !isExpanded);
+        menu.classList.toggle('hidden');
+        document.body.style.overflow = menu.classList.contains('hidden') ? '' : 'hidden';
+
+        if (!isExpanded && !menu.classList.contains('hidden')) {
+          const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+          if (focusableElements.length > 0) {
+            focusableElements[0].focus();
+          }
+        }
+      });
+
+      menu.addEventListener('keydown', function(event) {
+        if (menu.classList.contains('hidden') || event.key !== 'Tab') return;
+
+        const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+        if (focusableElements.length === 0) return;
+        const firstFocusableElement = focusableElements[0];
+        const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstFocusableElement) {
+            lastFocusableElement.focus();
+            event.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastFocusableElement) {
+            firstFocusableElement.focus();
+            event.preventDefault();
+          }
+        }
+      });
+
+      document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
+          menu.classList.add('hidden');
+          document.body.style.overflow = '';
+          menuButton.setAttribute('aria-expanded', 'false');
+          menuButton.focus();
+        }
+      });
+    </script>
+
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>
+    AOS.init();
+  </script>
+</body>
+</html>

--- a/careers/full-stack-developer.html
+++ b/careers/full-stack-developer.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Full-Stack Developer | Careers | Bridgee Solutions</title>
+  <meta name="description" content="Apply for the Full-Stack Developer position at Bridgee Solutions in Addis Ababa (Remote Friendly). Design, develop, and maintain web applications.">
+
+  <!-- Tailwind CSS CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Font Awesome -->
+  <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+  />
+
+  <!-- AOS (Animate on Scroll) -->
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+
+  <!-- Fonts and Custom Styles -->
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
+    body {
+      font-family: 'Poppins', sans-serif;
+      scroll-behavior: smooth;
+    }
+    .hero-gradient {
+      background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%);
+      animation: gradient 15s ease infinite;
+      background-size: 400% 400%;
+    }
+    @keyframes gradient {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+    .cta-button {
+      position: relative;
+      overflow: hidden;
+      z-index: 1;
+    }
+    .cta-button:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 0;
+      height: 100%;
+      background-color: rgba(255,255,255,0.1);
+      z-index: -1;
+      transition: width 0.3s ease;
+    }
+    .cta-button:hover:before {
+      width: 100%;
+    }
+  </style>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "JobPosting",
+      "title": "Full-Stack Developer",
+      "description": "<p>We are looking for a skilled Full-Stack Developer to design, develop, and maintain both front-end and back-end components of our web applications. You will work on exciting projects, contributing to all phases of the development lifecycle.</p>",
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "Bridgee Solutions",
+        "value": "FSD-001"
+      },
+      "datePosted": "2024-03-15",
+      "validThrough": "2024-04-15",
+      "employmentType": "FULL_TIME",
+      "hiringOrganization": {
+        "@type": "Organization",
+        "name": "Bridgee Solutions",
+        "sameAs": "https://www.bridgeesolutions.com",
+        "logo": "https://www.bridgeesolutions.com/Solutions.png"
+      },
+      "jobLocation": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Addis Ababa",
+          "addressCountry": "ET"
+        }
+      },
+      "jobLocationType": "TELECOMMUTE",
+      "applicantLocationRequirements": {
+        "@type": "Country",
+        "name": "Ethiopia"
+      }
+    }
+  </script>
+</head>
+
+<body class="bg-gray-50">
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-lg sticky top-0 z-50">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center">
+                <a href="../index.html" class="flex items-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-lg">
+                    <img src="../Solutions.png" alt="Bridgee Solutions Logo" class="h-12 w-auto" />
+                    <span class="ml-2 text-xl font-semibold text-gray-800">Bridgee <span class="text-blue-600">Solutions</span></span>
+                </a>
+                </div>
+
+                <div class="md:flex items-center hidden space-x-8">
+                    <a href="../index.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Home</a>
+                    <a href="../about.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">About Us</a>
+                    <a href="../services.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Services</a>
+                    <a href="../careers.html" class="text-blue-600 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Careers</a>
+                    <a href="../index.html#blog" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Blog</a>
+                    <a href="../contact.html" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+                <div class="md:hidden flex items-center">
+                    <button class="outline-none mobile-menu-button focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md" id="mobile-menu-button" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-menu">
+                        <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div class="mobile-menu hidden md:hidden fixed top-16 left-0 right-0 bg-white/30 backdrop-blur-lg shadow-lg z-50" id="mobile-menu">
+                <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 flex flex-col border-t">
+                    <a href="../index.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Home</a>
+                    <a href="../about.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">About Us</a>
+                    <a href="../services.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Services</a>
+                    <a href="../careers.html" class="px-3 py-2 rounded-md text-sm font-semibold text-blue-600 bg-blue-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Careers</a>
+                    <a href="../index.html#blog" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Blog</a>
+                    <a href="../contact.html" class="px-3 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 block text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <main id="job-detail-content" class="bg-white py-12 md:py-16">
+        <div class="container mx-auto px-6">
+            <div class="mb-8 text-sm" data-aos="fade-right">
+                <a href="../careers.html" class="text-blue-600 hover:text-blue-800 font-semibold transition duration-300 inline-flex items-center">
+                    <i class="fas fa-arrow-left mr-2"></i> Back to All Careers
+                </a>
+            </div>
+
+            <h1 class="text-3xl md:text-4xl font-bold text-blue-700 mb-2" data-aos="fade-up">Full-Stack Developer</h1>
+
+            <p class="text-lg text-gray-600 mb-6" data-aos="fade-up" data-aos-delay="100">
+                Location: Addis Ababa, Ethiopia - Remote Friendly | Job Type: Full-time
+            </p>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="200">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Role Overview</h2>
+                <p class="text-gray-700 leading-relaxed">
+                    We are looking for a skilled Full-Stack Developer to design, develop, and maintain both front-end and back-end components of our web applications. You will work on exciting projects, contributing to all phases of the development lifecycle and helping us deliver robust and scalable solutions for our clients.
+                </p>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Key Responsibilities</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Develop and maintain responsive user-facing features using modern front-end technologies (e.g., React, Vue, Angular).</li>
+                    <li>Design and implement server-side logic and APIs using back-end technologies (e.g., Node.js, Python/Django, PHP/Laravel).</li>
+                    <li>Manage databases, ensuring optimal performance and data integrity.</li>
+                    <li>Collaborate with UI/UX designers, product managers, and other stakeholders to create seamless user experiences.</li>
+                    <li>Write clean, well-documented, and testable code, participating in code reviews and agile processes.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="400">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Required Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Bachelor's degree in Computer Science, Engineering, or a related field.</li>
+                    <li>Proven experience as a Full-Stack Developer or similar role.</li>
+                    <li>Strong proficiency in front-end languages (HTML, CSS, JavaScript) and relevant frameworks.</li>
+                    <li>Solid experience with server-side languages (e.g., Node.js, Python, PHP) and respective frameworks.</li>
+                    <li>Familiarity with database technology such as MySQL, PostgreSQL, or MongoDB.</li>
+                    <li>Understanding of version control systems (e.g., Git).</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="500">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Preferred Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Experience with cloud platforms (AWS, Azure, Google Cloud).</li>
+                    <li>Knowledge of containerization technologies like Docker and Kubernetes.</li>
+                    <li>Familiarity with CI/CD pipelines and DevOps practices.</li>
+                    <li>Experience working in an Agile/Scrum development process.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="600">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">What We Offer (Benefits)</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Competitive salary and comprehensive benefits package.</li>
+                    <li>Flexible work arrangements, including remote options.</li>
+                    <li>Opportunities for continuous learning and professional development.</li>
+                    <li>A dynamic and collaborative work culture with impactful projects.</li>
+                    <li>Access to modern technologies and tools.</li>
+                </ul>
+            </section>
+
+            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
+                <p class="text-gray-700 leading-relaxed text-center">
+                    To apply, please send your CV, a cover letter, and a link to your portfolio (e.g., GitHub) to
+                    <a href="mailto:careers@bridgeesolutions.com?subject=Full-Stack Developer Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
+                    with the job title "Full-Stack Developer" in the subject line.
+                </p>
+                <p class="text-sm text-gray-600 mt-4 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+                </p>
+            </section>
+
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-12">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-12">
+                <div class="md:col-span-2">
+                    <a href="../index.html" class="flex items-center mb-6 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-lg">
+                    <img src="../Solutions_darkmode.png" alt="Bridgee Solutions Logo" class="h-8 w-auto mr-2">
+                    <span class="text-xl font-semibold">Bridgee <span class="text-blue-400">Solutions</span></span>
+                    </a>
+                    <p class="text-gray-300 mb-4">Your bridge to cost-effective, scalable outsourcing solutions with Ethiopian talent.</p>
+                    <div class="flex space-x-4">
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Facebook"><i class="fab fa-facebook-f"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Twitter"><i class="fab fa-twitter"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Instagram"><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Company</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../about.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">About Us</a></li>
+                        <li><a href="../careers.html" class="text-blue-400 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Careers</a></li>
+                        <li><a href="../index.html#blog" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Blog</a></li>
+                        <li><a href="../contact.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Contact</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Services</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../services.html#virtual-assistance" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Virtual Assistants</a></li>
+                        <li><a href="../services.html#software-development" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Software Development</a></li>
+                        <li><a href="../services.html#bpo-services" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">BPO Services</a></li>
+                        <li><a href="../services.html#custom-solutions" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Custom Solutions</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Legal</h3>
+                    <ul class="space-y-2">
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Privacy Policy</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Terms of Service</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">GDPR Compliance</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 mt-12 pt-8 text-center text-gray-300">
+                <p>© 2024 Bridgee Solutions. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+      const menuButton = document.getElementById('mobile-menu-button');
+      const menu = document.getElementById('mobile-menu');
+
+      menuButton.addEventListener('click', function() {
+        const isExpanded = menuButton.getAttribute('aria-expanded') === 'true' || false;
+        menuButton.setAttribute('aria-expanded', !isExpanded);
+        menu.classList.toggle('hidden');
+        document.body.style.overflow = menu.classList.contains('hidden') ? '' : 'hidden';
+
+        if (!isExpanded && !menu.classList.contains('hidden')) {
+          const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+          if (focusableElements.length > 0) {
+            focusableElements[0].focus();
+          }
+        }
+      });
+
+      menu.addEventListener('keydown', function(event) {
+        if (menu.classList.contains('hidden') || event.key !== 'Tab') return;
+
+        const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+        if (focusableElements.length === 0) return;
+        const firstFocusableElement = focusableElements[0];
+        const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstFocusableElement) {
+            lastFocusableElement.focus();
+            event.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastFocusableElement) {
+            firstFocusableElement.focus();
+            event.preventDefault();
+          }
+        }
+      });
+
+      document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
+          menu.classList.add('hidden');
+          document.body.style.overflow = '';
+          menuButton.setAttribute('aria-expanded', 'false');
+          menuButton.focus();
+        }
+      });
+    </script>
+
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>
+    AOS.init();
+  </script>
+</body>
+</html>

--- a/careers/ui-ux-designer.html
+++ b/careers/ui-ux-designer.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UI/UX Designer | Careers | Bridgee Solutions</title>
+  <meta name="description" content="Seeking a creative UI/UX Designer at Bridgee Solutions in Addis Ababa (Remote Friendly). Design intuitive and engaging user experiences for web and mobile applications.">
+
+  <!-- Tailwind CSS CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Font Awesome -->
+  <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+  />
+
+  <!-- AOS (Animate on Scroll) -->
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+
+  <!-- Fonts and Custom Styles -->
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
+    body {
+      font-family: 'Poppins', sans-serif;
+      scroll-behavior: smooth;
+    }
+    .hero-gradient {
+      background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%);
+      animation: gradient 15s ease infinite;
+      background-size: 400% 400%;
+    }
+    @keyframes gradient {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+    .cta-button {
+      position: relative;
+      overflow: hidden;
+      z-index: 1;
+    }
+    .cta-button:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 0;
+      height: 100%;
+      background-color: rgba(255,255,255,0.1);
+      z-index: -1;
+      transition: width 0.3s ease;
+    }
+    .cta-button:hover:before {
+      width: 100%;
+    }
+  </style>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "JobPosting",
+      "title": "UI/UX Designer",
+      "description": "<p>We are seeking a talented UI/UX Designer to create intuitive, engaging, and visually appealing user interfaces and experiences for our web and mobile applications. You will be responsible for the entire design process, from user research and wireframing to high-fidelity mockups and prototyping.</p>",
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "Bridgee Solutions",
+        "value": "UIUX-001"
+      },
+      "datePosted": "2024-03-15",
+      "validThrough": "2024-04-15",
+      "employmentType": "FULL_TIME",
+      "hiringOrganization": {
+        "@type": "Organization",
+        "name": "Bridgee Solutions",
+        "sameAs": "https://www.bridgeesolutions.com",
+        "logo": "https://www.bridgeesolutions.com/Solutions.png"
+      },
+      "jobLocation": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Addis Ababa",
+          "addressCountry": "ET"
+        }
+      },
+      "jobLocationType": "TELECOMMUTE",
+      "applicantLocationRequirements": {
+        "@type": "Country",
+        "name": "Ethiopia"
+      }
+    }
+  </script>
+</head>
+
+<body class="bg-gray-50">
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-lg sticky top-0 z-50">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center">
+                <a href="../index.html" class="flex items-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-lg">
+                    <img src="../Solutions.png" alt="Bridgee Solutions Logo" class="h-12 w-auto" />
+                    <span class="ml-2 text-xl font-semibold text-gray-800">Bridgee <span class="text-blue-600">Solutions</span></span>
+                </a>
+                </div>
+
+                <div class="md:flex items-center hidden space-x-8">
+                    <a href="../index.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Home</a>
+                    <a href="../about.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">About Us</a>
+                    <a href="../services.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Services</a>
+                    <a href="../careers.html" class="text-blue-600 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Careers</a>
+                    <a href="../index.html#blog" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Blog</a>
+                    <a href="../contact.html" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+                <div class="md:hidden flex items-center">
+                    <button class="outline-none mobile-menu-button focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md" id="mobile-menu-button" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-menu">
+                        <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div class="mobile-menu hidden md:hidden fixed top-16 left-0 right-0 bg-white/30 backdrop-blur-lg shadow-lg z-50" id="mobile-menu">
+                <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 flex flex-col border-t">
+                    <a href="../index.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Home</a>
+                    <a href="../about.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">About Us</a>
+                    <a href="../services.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Services</a>
+                    <a href="../careers.html" class="px-3 py-2 rounded-md text-sm font-semibold text-blue-600 bg-blue-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Careers</a>
+                    <a href="../index.html#blog" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Blog</a>
+                    <a href="../contact.html" class="px-3 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 block text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <main id="job-detail-content" class="bg-white py-12 md:py-16">
+        <div class="container mx-auto px-6">
+            <div class="mb-8 text-sm" data-aos="fade-right">
+                <a href="../careers.html" class="text-blue-600 hover:text-blue-800 font-semibold transition duration-300 inline-flex items-center">
+                    <i class="fas fa-arrow-left mr-2"></i> Back to All Careers
+                </a>
+            </div>
+
+            <h1 class="text-3xl md:text-4xl font-bold text-blue-700 mb-2" data-aos="fade-up">UI/UX Designer</h1>
+
+            <p class="text-lg text-gray-600 mb-6" data-aos="fade-up" data-aos-delay="100">
+                Location: Addis Ababa, Ethiopia - Remote Friendly | Job Type: Full-time
+            </p>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="200">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Role Overview</h2>
+                <p class="text-gray-700 leading-relaxed">
+                    We are seeking a talented and creative UI/UX Designer to craft intuitive, engaging, and visually appealing user interfaces and experiences for our web and mobile applications. You will be responsible for the entire design process, from conducting user research and creating wireframes to developing high-fidelity mockups and interactive prototypes.
+                </p>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Key Responsibilities</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Conduct user research, interviews, and usability testing to understand user needs and pain points.</li>
+                    <li>Create user personas, journey maps, wireframes, and sitemaps to guide design decisions.</li>
+                    <li>Develop high-fidelity mockups, visual designs, and interactive prototypes for web and mobile platforms.</li>
+                    <li>Collaborate closely with developers, product managers, and other stakeholders to ensure design feasibility and consistency.</li>
+                    <li>Maintain and evolve design systems and style guides.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="400">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Required Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Proven experience as a UI/UX Designer or similar role, with a strong portfolio showcasing your design work.</li>
+                    <li>Proficiency in design and prototyping tools such as Figma, Sketch, Adobe XD, or similar.</li>
+                    <li>Solid understanding of user-centered design principles, usability, and accessibility best practices.</li>
+                    <li>Excellent visual design skills with a keen eye for detail, typography, color, and layout.</li>
+                    <li>Ability to effectively communicate design ideas and rationale to stakeholders.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="500">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Preferred Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Experience designing for responsive web applications and native mobile apps (iOS and Android).</li>
+                    <li>Knowledge of HTML, CSS, and basic front-end development concepts.</li>
+                    <li>Experience working in an agile development environment.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="600">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">What We Offer (Benefits)</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Competitive remuneration and benefits.</li>
+                    <li>Flexible work options, including remote opportunities.</li>
+                    <li>A creative and collaborative environment to grow your skills.</li>
+                    <li>Opportunity to work on diverse projects and shape user experiences.</li>
+                    <li>Access to industry-standard design tools and resources.</li>
+                </ul>
+            </section>
+
+            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
+                <p class="text-gray-700 leading-relaxed text-center">
+                    To apply, please submit your CV, a cover letter, and your portfolio (link or PDF) to
+                    <a href="mailto:careers@bridgeesolutions.com?subject=UI/UX Designer Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
+                    with the job title "UI/UX Designer" in the subject line.
+                </p>
+                <p class="text-sm text-gray-600 mt-4 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+                </p>
+            </section>
+
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-12">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-12">
+                <div class="md:col-span-2">
+                    <a href="../index.html" class="flex items-center mb-6 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-lg">
+                    <img src="../Solutions_darkmode.png" alt="Bridgee Solutions Logo" class="h-8 w-auto mr-2">
+                    <span class="text-xl font-semibold">Bridgee <span class="text-blue-400">Solutions</span></span>
+                    </a>
+                    <p class="text-gray-300 mb-4">Your bridge to cost-effective, scalable outsourcing solutions with Ethiopian talent.</p>
+                    <div class="flex space-x-4">
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Facebook"><i class="fab fa-facebook-f"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Twitter"><i class="fab fa-twitter"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Instagram"><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Company</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../about.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">About Us</a></li>
+                        <li><a href="../careers.html" class="text-blue-400 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Careers</a></li>
+                        <li><a href="../index.html#blog" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Blog</a></li>
+                        <li><a href="../contact.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Contact</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Services</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../services.html#virtual-assistance" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Virtual Assistants</a></li>
+                        <li><a href="../services.html#software-development" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Software Development</a></li>
+                        <li><a href="../services.html#bpo-services" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">BPO Services</a></li>
+                        <li><a href="../services.html#custom-solutions" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Custom Solutions</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Legal</h3>
+                    <ul class="space-y-2">
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Privacy Policy</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Terms of Service</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">GDPR Compliance</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 mt-12 pt-8 text-center text-gray-300">
+                <p>© 2024 Bridgee Solutions. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+      const menuButton = document.getElementById('mobile-menu-button');
+      const menu = document.getElementById('mobile-menu');
+
+      menuButton.addEventListener('click', function() {
+        const isExpanded = menuButton.getAttribute('aria-expanded') === 'true' || false;
+        menuButton.setAttribute('aria-expanded', !isExpanded);
+        menu.classList.toggle('hidden');
+        document.body.style.overflow = menu.classList.contains('hidden') ? '' : 'hidden';
+
+        if (!isExpanded && !menu.classList.contains('hidden')) {
+          const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+          if (focusableElements.length > 0) {
+            focusableElements[0].focus();
+          }
+        }
+      });
+
+      menu.addEventListener('keydown', function(event) {
+        if (menu.classList.contains('hidden') || event.key !== 'Tab') return;
+
+        const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+        if (focusableElements.length === 0) return;
+        const firstFocusableElement = focusableElements[0];
+        const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstFocusableElement) {
+            lastFocusableElement.focus();
+            event.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastFocusableElement) {
+            firstFocusableElement.focus();
+            event.preventDefault();
+          }
+        }
+      });
+
+      document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
+          menu.classList.add('hidden');
+          document.body.style.overflow = '';
+          menuButton.setAttribute('aria-expanded', 'false');
+          menuButton.focus();
+        }
+      });
+    </script>
+
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>
+    AOS.init();
+  </script>
+</body>
+</html>

--- a/careers/virtual-assistant.html
+++ b/careers/virtual-assistant.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Virtual Assistant | Careers | Bridgee Solutions</title>
+  <meta name="description" content="Apply for the Virtual Assistant position at Bridgee Solutions. Join our team in Addis Ababa (Remote Friendly) and provide essential administrative, technical, and creative assistance to our clients.">
+
+  <!-- Tailwind CSS CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Font Awesome -->
+  <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+  />
+
+  <!-- AOS (Animate on Scroll) -->
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+
+  <!-- Fonts and Custom Styles -->
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
+    body {
+      font-family: 'Poppins', sans-serif;
+      scroll-behavior: smooth;
+    }
+    .hero-gradient {
+      background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%);
+      animation: gradient 15s ease infinite;
+      background-size: 400% 400%;
+    }
+    @keyframes gradient {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+    .cta-button {
+      position: relative;
+      overflow: hidden;
+      z-index: 1;
+    }
+    .cta-button:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 0;
+      height: 100%;
+      background-color: rgba(255,255,255,0.1);
+      z-index: -1;
+      transition: width 0.3s ease;
+    }
+    .cta-button:hover:before {
+      width: 100%;
+    }
+  </style>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "JobPosting",
+      "title": "Virtual Assistant",
+      "description": "<p>We are seeking a highly organized and proactive Virtual Assistant to provide comprehensive administrative, technical, and creative assistance to our clients. The ideal candidate will be a master of multitasking, possess excellent communication skills, and thrive in a remote work environment.</p>",
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "Bridgee Solutions",
+        "value": "VA-001"
+      },
+      "datePosted": "2024-03-15", // Placeholder - ideally this would be dynamic
+      "validThrough": "2024-04-15", // Placeholder
+      "employmentType": "FULL_TIME",
+      "hiringOrganization": {
+        "@type": "Organization",
+        "name": "Bridgee Solutions",
+        "sameAs": "https://www.bridgeesolutions.com", // Assuming
+        "logo": "https://www.bridgeesolutions.com/Solutions.png" // Assuming
+      },
+      "jobLocation": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Addis Ababa",
+          "addressCountry": "ET"
+        }
+      },
+      "jobLocationType": "TELECOMMUTE",
+      "applicantLocationRequirements": {
+        "@type": "Country",
+        "name": "Ethiopia"
+      }
+      // Add more relevant properties like responsibilities, qualifications, etc.
+    }
+  </script>
+</head>
+
+<body class="bg-gray-50">
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-lg sticky top-0 z-50">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center">
+                <a href="../index.html" class="flex items-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-lg">
+                    <img src="../Solutions.png" alt="Bridgee Solutions Logo" class="h-12 w-auto" />
+                    <span class="ml-2 text-xl font-semibold text-gray-800">Bridgee <span class="text-blue-600">Solutions</span></span>
+                </a>
+                </div>
+
+                <div class="md:flex items-center hidden space-x-8">
+                    <a href="../index.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Home</a>
+                    <a href="../about.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">About Us</a>
+                    <a href="../services.html" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Services</a>
+                    <a href="../careers.html" class="text-blue-600 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Careers</a>
+                    <a href="../index.html#blog" class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Blog</a>
+                    <a href="../contact.html" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+                <div class="md:hidden flex items-center">
+                    <button class="outline-none mobile-menu-button focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md" id="mobile-menu-button" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-menu">
+                        <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div class="mobile-menu hidden md:hidden fixed top-16 left-0 right-0 bg-white/30 backdrop-blur-lg shadow-lg z-50" id="mobile-menu">
+                <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 flex flex-col border-t">
+                    <a href="../index.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Home</a>
+                    <a href="../about.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">About Us</a>
+                    <a href="../services.html" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Services</a>
+                    <a href="../careers.html" class="px-3 py-2 rounded-md text-sm font-semibold text-blue-600 bg-blue-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Careers</a>
+                    <a href="../index.html#blog" class="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-gray-50">Blog</a>
+                    <a href="../contact.html" class="px-3 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 block text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">Contact Us</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <main id="job-detail-content" class="bg-white py-12 md:py-16">
+        <div class="container mx-auto px-6">
+            <div class="mb-8 text-sm" data-aos="fade-right">
+                <a href="../careers.html" class="text-blue-600 hover:text-blue-800 font-semibold transition duration-300 inline-flex items-center">
+                    <i class="fas fa-arrow-left mr-2"></i> Back to All Careers
+                </a>
+            </div>
+
+            <!-- Job Title (H1) -->
+            <h1 class="text-3xl md:text-4xl font-bold text-blue-700 mb-2" data-aos="fade-up">Virtual Assistant</h1>
+
+            <!-- Location & Job Type -->
+            <p class="text-lg text-gray-600 mb-6" data-aos="fade-up" data-aos-delay="100">
+                Location: Addis Ababa, Ethiopia - Remote Friendly | Job Type: Full-time
+            </p>
+
+            <!-- Brief Role Overview (2-3 sentences) -->
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="200">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Role Overview</h2>
+                <p class="text-gray-700 leading-relaxed">
+                    We are seeking a highly organized and proactive Virtual Assistant to provide comprehensive administrative, technical, and creative assistance to our clients. The ideal candidate will be a master of multitasking, possess excellent communication skills, and thrive in a remote work environment, helping clients achieve their business goals efficiently.
+                </p>
+            </section>
+
+            <!-- Key Responsibilities -->
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Key Responsibilities</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Manage email correspondence, calendars, and schedule appointments.</li>
+                    <li>Perform data entry, document preparation, and file management.</li>
+                    <li>Conduct online research and compile information as requested.</li>
+                    <li>Provide customer service support via email, chat, or phone.</li>
+                    <li>Assist with social media management and content creation tasks.</li>
+                </ul>
+            </section>
+
+            <!-- Required Qualifications -->
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="400">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Required Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Proven experience as a Virtual Assistant or relevant administrative role.</li>
+                    <li>Excellent written and verbal communication skills in English.</li>
+                    <li>Proficiency in MS Office Suite (Word, Excel, PowerPoint) and Google Workspace.</li>
+                    <li>Strong organizational and time-management skills.</li>
+                    <li>Ability to work independently and manage multiple tasks simultaneously.</li>
+                    <li>High-speed internet access and a quiet work environment.</li>
+                </ul>
+            </section>
+
+            <!-- Preferred Qualifications (Optional Section) -->
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="500">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Preferred Qualifications</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Experience with project management tools (e.g., Asana, Trello).</li>
+                    <li>Familiarity with CRM software (e.g., HubSpot, Salesforce).</li>
+                    <li>Basic graphic design or video editing skills.</li>
+                </ul>
+            </section>
+
+            <!-- Benefits -->
+            <section class="mb-8" data-aos="fade-up" data-aos-delay="600">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-3">What We Offer (Benefits)</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
+                    <li>Competitive salary based on experience and skills.</li>
+                    <li>Flexible work hours and remote work opportunities.</li>
+                    <li>Opportunities for professional development and skills training.</li>
+                    <li>A collaborative, supportive, and dynamic team environment.</li>
+                    <li>Chance to work with diverse clients and challenging projects.</li>
+                </ul>
+            </section>
+
+            <!-- How to Apply -->
+            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
+                <p class="text-gray-700 leading-relaxed text-center">
+                    To apply, please send your CV and a cover letter to
+                    <a href="mailto:careers@bridgeesolutions.com?subject=Virtual Assistant Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
+                    with the job title "Virtual Assistant" in the subject line.
+                </p>
+                <p class="text-sm text-gray-600 mt-4 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+                </p>
+            </section>
+
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-12">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-12">
+                <div class="md:col-span-2">
+                    <a href="../index.html" class="flex items-center mb-6 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-lg">
+                    <img src="../Solutions_darkmode.png" alt="Bridgee Solutions Logo" class="h-8 w-auto mr-2">
+                    <span class="text-xl font-semibold">Bridgee <span class="text-blue-400">Solutions</span></span>
+                    </a>
+                    <p class="text-gray-300 mb-4">Your bridge to cost-effective, scalable outsourcing solutions with Ethiopian talent.</p>
+                    <div class="flex space-x-4">
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Facebook"><i class="fab fa-facebook-f"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Twitter"><i class="fab fa-twitter"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+                        <a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md" aria-label="Bridgee Solutions on Instagram"><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Company</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../about.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">About Us</a></li>
+                        <li><a href="../careers.html" class="text-blue-400 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Careers</a></li>
+                        <li><a href="../index.html#blog" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Blog</a></li>
+                        <li><a href="../contact.html" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Contact</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Services</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../services.html#virtual-assistance" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Virtual Assistants</a></li>
+                        <li><a href="../services.html#software-development" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Software Development</a></li>
+                        <li><a href="../services.html#bpo-services" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">BPO Services</a></li>
+                        <li><a href="../services.html#custom-solutions" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Custom Solutions</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">Legal</h3>
+                    <ul class="space-y-2">
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Privacy Policy</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">Terms of Service</a></li>
+                        <li><a href="#" class="text-gray-300 hover:text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 focus:ring-offset-gray-900 rounded-md">GDPR Compliance</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 mt-12 pt-8 text-center text-gray-300">
+                <p>© 2024 Bridgee Solutions. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+      const menuButton = document.getElementById('mobile-menu-button');
+      const menu = document.getElementById('mobile-menu');
+
+      menuButton.addEventListener('click', function() {
+        const isExpanded = menuButton.getAttribute('aria-expanded') === 'true' || false;
+        menuButton.setAttribute('aria-expanded', !isExpanded);
+        menu.classList.toggle('hidden');
+        document.body.style.overflow = menu.classList.contains('hidden') ? '' : 'hidden';
+
+        if (!isExpanded && !menu.classList.contains('hidden')) { // If menu is now open
+          const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+          if (focusableElements.length > 0) {
+            focusableElements[0].focus();
+          }
+        }
+      });
+
+      menu.addEventListener('keydown', function(event) {
+        if (menu.classList.contains('hidden') || event.key !== 'Tab') return;
+
+        const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+        if (focusableElements.length === 0) return;
+        const firstFocusableElement = focusableElements[0];
+        const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey) { // Shift + Tab
+          if (document.activeElement === firstFocusableElement) {
+            lastFocusableElement.focus();
+            event.preventDefault();
+          }
+        } else { // Tab
+          if (document.activeElement === lastFocusableElement) {
+            firstFocusableElement.focus();
+            event.preventDefault();
+          }
+        }
+      });
+
+      document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
+          menu.classList.add('hidden');
+          document.body.style.overflow = '';
+          menuButton.setAttribute('aria-expanded', 'false');
+          menuButton.focus();
+        }
+      });
+    </script>
+
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>
+    AOS.init();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- I created five job detail pages in a new `/careers/` subdirectory:
  - careers/virtual-assistant.html
  - careers/full-stack-developer.html
  - careers/customer-support-specialist.html
  - careers/ui-ux-designer.html
  - careers/business-analyst.html
- Each job detail page is based on a standardized template including sections for job title, overview, responsibilities, qualifications, benefits, and a 'How to Apply' mailto link.
- I populated the pages with generic, role-relevant placeholder content.
- I ensured consistent site navigation and footer with correct relative paths.
- I added unique titles, meta descriptions, and JobPosting schema.org structured data to each job page.
- I updated the main `careers.html` page to link the open positions to their respective new detail pages.