### PR TITLE
feat: Add application form to job detail pages

### DIFF
--- a/careers/business-analyst.html
+++ b/careers/business-analyst.html
@@ -198,15 +198,46 @@
                 </ul>
             </section>
 
-            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
-                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
-                <p class="text-gray-700 leading-relaxed text-center">
-                    To apply, please send your CV and a cover letter outlining your analytical skills and project experience to
-                    <a href="mailto:careers@bridgeesolutions.com?subject=Business Analyst Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
-                    with the job title "Business Analyst" in the subject line.
-                </p>
-                <p class="text-sm text-gray-600 mt-4 text-center">
-                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+            <!-- Apply for this Role Section -->
+            <section class="mt-10 py-8 bg-blue-50 p-6 md:p-8 rounded-lg shadow-lg" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl md:text-3xl font-semibold text-gray-800 mb-6 text-center">Apply for this Role</h2>
+
+                <form action="#" method="POST" enctype="multipart/form-data" class="space-y-6 max-w-xl mx-auto">
+                    <div>
+                        <label for="full_name" class="block text-sm font-medium text-gray-700 mb-1">Full Name</label>
+                        <input type="text" name="full_name" id="full_name" placeholder="Enter your full name" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="email" class="block text-sm font-medium text-gray-700 mb-1">Email Address</label>
+                        <input type="email" name="email" id="email" placeholder="you@example.com" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="phone_number" class="block text-sm font-medium text-gray-700 mb-1">Phone Number (Optional)</label>
+                        <input type="tel" name="phone_number" id="phone_number" placeholder="+251 ..." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="cover_letter" class="block text-sm font-medium text-gray-700 mb-1">Cover Letter (Optional)</label>
+                        <textarea name="cover_letter" id="cover_letter" rows="4" placeholder="Paste your cover letter here or briefly tell us why you're a good fit." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"></textarea>
+                    </div>
+
+                    <div>
+                        <label for="cv_upload" class="block text-sm font-medium text-gray-700 mb-1">Upload CV (PDF, DOC, DOCX)</label>
+                        <input type="file" name="cv_upload" id="cv_upload" required accept=".pdf,.doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-100 file:text-blue-700 hover:file:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                    </div>
+
+                    <input type="hidden" name="job_title" id="job_title_hidden" value="Business Analyst">
+
+                    <div class="text-center pt-4">
+                        <button type="submit" class="inline-flex justify-center py-3 px-6 border border-transparent shadow-sm text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-150 ease-in-out">
+                            Submit Application
+                        </button>
+                    </div>
+                </form>
+                <p class="text-xs text-gray-500 mt-6 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees. By submitting your application, you agree to our Privacy Policy (link placeholder).
                 </p>
             </section>
 

--- a/careers/customer-support-specialist.html
+++ b/careers/customer-support-specialist.html
@@ -198,15 +198,46 @@
                 </ul>
             </section>
 
-            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
-                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
-                <p class="text-gray-700 leading-relaxed text-center">
-                    To apply, please send your CV and a cover letter detailing your customer service philosophy to
-                    <a href="mailto:careers@bridgeesolutions.com?subject=Customer Support Specialist Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
-                    with the job title "Customer Support Specialist" in the subject line.
-                </p>
-                <p class="text-sm text-gray-600 mt-4 text-center">
-                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+            <!-- Apply for this Role Section -->
+            <section class="mt-10 py-8 bg-blue-50 p-6 md:p-8 rounded-lg shadow-lg" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl md:text-3xl font-semibold text-gray-800 mb-6 text-center">Apply for this Role</h2>
+
+                <form action="#" method="POST" enctype="multipart/form-data" class="space-y-6 max-w-xl mx-auto">
+                    <div>
+                        <label for="full_name" class="block text-sm font-medium text-gray-700 mb-1">Full Name</label>
+                        <input type="text" name="full_name" id="full_name" placeholder="Enter your full name" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="email" class="block text-sm font-medium text-gray-700 mb-1">Email Address</label>
+                        <input type="email" name="email" id="email" placeholder="you@example.com" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="phone_number" class="block text-sm font-medium text-gray-700 mb-1">Phone Number (Optional)</label>
+                        <input type="tel" name="phone_number" id="phone_number" placeholder="+251 ..." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="cover_letter" class="block text-sm font-medium text-gray-700 mb-1">Cover Letter (Optional)</label>
+                        <textarea name="cover_letter" id="cover_letter" rows="4" placeholder="Paste your cover letter here or briefly tell us why you're a good fit." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"></textarea>
+                    </div>
+
+                    <div>
+                        <label for="cv_upload" class="block text-sm font-medium text-gray-700 mb-1">Upload CV (PDF, DOC, DOCX)</label>
+                        <input type="file" name="cv_upload" id="cv_upload" required accept=".pdf,.doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-100 file:text-blue-700 hover:file:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                    </div>
+
+                    <input type="hidden" name="job_title" id="job_title_hidden" value="Customer Support Specialist">
+
+                    <div class="text-center pt-4">
+                        <button type="submit" class="inline-flex justify-center py-3 px-6 border border-transparent shadow-sm text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-150 ease-in-out">
+                            Submit Application
+                        </button>
+                    </div>
+                </form>
+                <p class="text-xs text-gray-500 mt-6 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees. By submitting your application, you agree to our Privacy Policy (link placeholder).
                 </p>
             </section>
 

--- a/careers/full-stack-developer.html
+++ b/careers/full-stack-developer.html
@@ -200,15 +200,46 @@
                 </ul>
             </section>
 
-            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
-                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
-                <p class="text-gray-700 leading-relaxed text-center">
-                    To apply, please send your CV, a cover letter, and a link to your portfolio (e.g., GitHub) to
-                    <a href="mailto:careers@bridgeesolutions.com?subject=Full-Stack Developer Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
-                    with the job title "Full-Stack Developer" in the subject line.
-                </p>
-                <p class="text-sm text-gray-600 mt-4 text-center">
-                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+            <!-- Apply for this Role Section -->
+            <section class="mt-10 py-8 bg-blue-50 p-6 md:p-8 rounded-lg shadow-lg" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl md:text-3xl font-semibold text-gray-800 mb-6 text-center">Apply for this Role</h2>
+
+                <form action="#" method="POST" enctype="multipart/form-data" class="space-y-6 max-w-xl mx-auto">
+                    <div>
+                        <label for="full_name" class="block text-sm font-medium text-gray-700 mb-1">Full Name</label>
+                        <input type="text" name="full_name" id="full_name" placeholder="Enter your full name" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="email" class="block text-sm font-medium text-gray-700 mb-1">Email Address</label>
+                        <input type="email" name="email" id="email" placeholder="you@example.com" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="phone_number" class="block text-sm font-medium text-gray-700 mb-1">Phone Number (Optional)</label>
+                        <input type="tel" name="phone_number" id="phone_number" placeholder="+251 ..." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="cover_letter" class="block text-sm font-medium text-gray-700 mb-1">Cover Letter (Optional)</label>
+                        <textarea name="cover_letter" id="cover_letter" rows="4" placeholder="Paste your cover letter here or briefly tell us why you're a good fit." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"></textarea>
+                    </div>
+
+                    <div>
+                        <label for="cv_upload" class="block text-sm font-medium text-gray-700 mb-1">Upload CV (PDF, DOC, DOCX)</label>
+                        <input type="file" name="cv_upload" id="cv_upload" required accept=".pdf,.doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-100 file:text-blue-700 hover:file:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                    </div>
+
+                    <input type="hidden" name="job_title" id="job_title_hidden" value="Full-Stack Developer">
+
+                    <div class="text-center pt-4">
+                        <button type="submit" class="inline-flex justify-center py-3 px-6 border border-transparent shadow-sm text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-150 ease-in-out">
+                            Submit Application
+                        </button>
+                    </div>
+                </form>
+                <p class="text-xs text-gray-500 mt-6 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees. By submitting your application, you agree to our Privacy Policy (link placeholder).
                 </p>
             </section>
 

--- a/careers/ui-ux-designer.html
+++ b/careers/ui-ux-designer.html
@@ -198,15 +198,46 @@
                 </ul>
             </section>
 
-            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
-                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
-                <p class="text-gray-700 leading-relaxed text-center">
-                    To apply, please submit your CV, a cover letter, and your portfolio (link or PDF) to
-                    <a href="mailto:careers@bridgeesolutions.com?subject=UI/UX Designer Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
-                    with the job title "UI/UX Designer" in the subject line.
-                </p>
-                <p class="text-sm text-gray-600 mt-4 text-center">
-                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+            <!-- Apply for this Role Section -->
+            <section class="mt-10 py-8 bg-blue-50 p-6 md:p-8 rounded-lg shadow-lg" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl md:text-3xl font-semibold text-gray-800 mb-6 text-center">Apply for this Role</h2>
+
+                <form action="#" method="POST" enctype="multipart/form-data" class="space-y-6 max-w-xl mx-auto">
+                    <div>
+                        <label for="full_name" class="block text-sm font-medium text-gray-700 mb-1">Full Name</label>
+                        <input type="text" name="full_name" id="full_name" placeholder="Enter your full name" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="email" class="block text-sm font-medium text-gray-700 mb-1">Email Address</label>
+                        <input type="email" name="email" id="email" placeholder="you@example.com" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="phone_number" class="block text-sm font-medium text-gray-700 mb-1">Phone Number (Optional)</label>
+                        <input type="tel" name="phone_number" id="phone_number" placeholder="+251 ..." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="cover_letter" class="block text-sm font-medium text-gray-700 mb-1">Cover Letter (Optional)</label>
+                        <textarea name="cover_letter" id="cover_letter" rows="4" placeholder="Paste your cover letter here or briefly tell us why you're a good fit." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"></textarea>
+                    </div>
+
+                    <div>
+                        <label for="cv_upload" class="block text-sm font-medium text-gray-700 mb-1">Upload CV (PDF, DOC, DOCX)</label>
+                        <input type="file" name="cv_upload" id="cv_upload" required accept=".pdf,.doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-100 file:text-blue-700 hover:file:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                    </div>
+
+                    <input type="hidden" name="job_title" id="job_title_hidden" value="UI/UX Designer">
+
+                    <div class="text-center pt-4">
+                        <button type="submit" class="inline-flex justify-center py-3 px-6 border border-transparent shadow-sm text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-150 ease-in-out">
+                            Submit Application
+                        </button>
+                    </div>
+                </form>
+                <p class="text-xs text-gray-500 mt-6 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees. By submitting your application, you agree to our Privacy Policy (link placeholder).
                 </p>
             </section>
 

--- a/careers/virtual-assistant.html
+++ b/careers/virtual-assistant.html
@@ -67,14 +67,14 @@
         "name": "Bridgee Solutions",
         "value": "VA-001"
       },
-      "datePosted": "2024-03-15", // Placeholder - ideally this would be dynamic
-      "validThrough": "2024-04-15", // Placeholder
+      "datePosted": "2024-03-15",
+      "validThrough": "2024-04-15",
       "employmentType": "FULL_TIME",
       "hiringOrganization": {
         "@type": "Organization",
         "name": "Bridgee Solutions",
-        "sameAs": "https://www.bridgeesolutions.com", // Assuming
-        "logo": "https://www.bridgeesolutions.com/Solutions.png" // Assuming
+        "sameAs": "https://www.bridgeesolutions.com",
+        "logo": "https://www.bridgeesolutions.com/Solutions.png"
       },
       "jobLocation": {
         "@type": "Place",
@@ -89,7 +89,6 @@
         "@type": "Country",
         "name": "Ethiopia"
       }
-      // Add more relevant properties like responsibilities, qualifications, etc.
     }
   </script>
 </head>
@@ -152,7 +151,7 @@
                 Location: Addis Ababa, Ethiopia - Remote Friendly | Job Type: Full-time
             </p>
 
-            <!-- Brief Role Overview (2-3 sentences) -->
+            <!-- Brief Role Overview -->
             <section class="mb-8" data-aos="fade-up" data-aos-delay="200">
                 <h2 class="text-2xl font-semibold text-gray-800 mb-3">Role Overview</h2>
                 <p class="text-gray-700 leading-relaxed">
@@ -185,7 +184,7 @@
                 </ul>
             </section>
 
-            <!-- Preferred Qualifications (Optional Section) -->
+            <!-- Preferred Qualifications -->
             <section class="mb-8" data-aos="fade-up" data-aos-delay="500">
                 <h2 class="text-2xl font-semibold text-gray-800 mb-3">Preferred Qualifications</h2>
                 <ul class="list-disc list-inside text-gray-700 space-y-2 pl-4 leading-relaxed">
@@ -207,16 +206,46 @@
                 </ul>
             </section>
 
-            <!-- How to Apply -->
-            <section class="mt-10 py-8 bg-blue-50 p-6 rounded-lg shadow-md" data-aos="fade-up" data-aos-delay="700">
-                <h2 class="text-2xl font-semibold text-gray-800 mb-4 text-center">How to Apply</h2>
-                <p class="text-gray-700 leading-relaxed text-center">
-                    To apply, please send your CV and a cover letter to
-                    <a href="mailto:careers@bridgeesolutions.com?subject=Virtual Assistant Application" class="text-blue-600 font-semibold hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">careers@bridgeesolutions.com</a>
-                    with the job title "Virtual Assistant" in the subject line.
-                </p>
-                <p class="text-sm text-gray-600 mt-4 text-center">
-                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees.
+            <!-- Apply for this Role Section -->
+            <section class="mt-10 py-8 bg-blue-50 p-6 md:p-8 rounded-lg shadow-lg" data-aos="fade-up" data-aos-delay="700">
+                <h2 class="text-2xl md:text-3xl font-semibold text-gray-800 mb-6 text-center">Apply for this Role</h2>
+
+                <form action="#" method="POST" enctype="multipart/form-data" class="space-y-6 max-w-xl mx-auto">
+                    <div>
+                        <label for="full_name" class="block text-sm font-medium text-gray-700 mb-1">Full Name</label>
+                        <input type="text" name="full_name" id="full_name" placeholder="Enter your full name" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="email" class="block text-sm font-medium text-gray-700 mb-1">Email Address</label>
+                        <input type="email" name="email" id="email" placeholder="you@example.com" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="phone_number" class="block text-sm font-medium text-gray-700 mb-1">Phone Number (Optional)</label>
+                        <input type="tel" name="phone_number" id="phone_number" placeholder="+251 ..." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                    </div>
+
+                    <div>
+                        <label for="cover_letter" class="block text-sm font-medium text-gray-700 mb-1">Cover Letter (Optional)</label>
+                        <textarea name="cover_letter" id="cover_letter" rows="4" placeholder="Paste your cover letter here or briefly tell us why you're a good fit." class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"></textarea>
+                    </div>
+
+                    <div>
+                        <label for="cv_upload" class="block text-sm font-medium text-gray-700 mb-1">Upload CV (PDF, DOC, DOCX)</label>
+                        <input type="file" name="cv_upload" id="cv_upload" required accept=".pdf,.doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-100 file:text-blue-700 hover:file:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                    </div>
+
+                    <input type="hidden" name="job_title" id="job_title_hidden" value="Virtual Assistant">
+
+                    <div class="text-center pt-4">
+                        <button type="submit" class="inline-flex justify-center py-3 px-6 border border-transparent shadow-sm text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-150 ease-in-out">
+                            Submit Application
+                        </button>
+                    </div>
+                </form>
+                <p class="text-xs text-gray-500 mt-6 text-center">
+                    Bridgee Solutions is an equal opportunity employer. We celebrate diversity and are committed to creating an inclusive environment for all employees. By submitting your application, you agree to our Privacy Policy (link placeholder).
                 </p>
             </section>
 
@@ -283,7 +312,7 @@
         menu.classList.toggle('hidden');
         document.body.style.overflow = menu.classList.contains('hidden') ? '' : 'hidden';
 
-        if (!isExpanded && !menu.classList.contains('hidden')) { // If menu is now open
+        if (!isExpanded && !menu.classList.contains('hidden')) {
           const focusableElements = menu.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
           if (focusableElements.length > 0) {
             focusableElements[0].focus();
@@ -299,12 +328,12 @@
         const firstFocusableElement = focusableElements[0];
         const lastFocusableElement = focusableElements[focusableElements.length - 1];
 
-        if (event.shiftKey) { // Shift + Tab
+        if (event.shiftKey) {
           if (document.activeElement === firstFocusableElement) {
             lastFocusableElement.focus();
             event.preventDefault();
           }
-        } else { // Tab
+        } else {
           if (document.activeElement === lastFocusableElement) {
             firstFocusableElement.focus();
             event.preventDefault();


### PR DESCRIPTION
- Replaced the 'How to Apply' mailto: link on individual job detail pages with a structured HTML application form.
- The form includes fields for Full Name, Email, Phone (optional), Cover Letter (optional), and CV Upload (required .pdf, .doc, .docx).
- A hidden field 'job_title' is included in each form, dynamically populated with the respective job title.
- Styled the form using Tailwind CSS for consistency with the site design.
- The form's action is currently '#' as backend implementation is separate.
- Updated all 5 job detail pages in the /careers/ directory:
  - careers/virtual-assistant.html
  - careers/full-stack-developer.html
  - careers/customer-support-specialist.html
  - careers/ui-ux-designer.html
  - careers/business-analyst.html

Conceptual backend requirements for processing these forms and handling file uploads have been documented separately.