### PR TITLE
Fix: Adjust testimonial carousel speed and verify quote formatting

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -754,7 +754,7 @@
         loop: true,
         slidesPerView: 'auto', // Key for continuous scroll with variable width slides
         spaceBetween: 40,    // Adjust as needed, was 30-40
-        speed: 8000,         // Duration of the entire loop transition (e.g., 8 seconds)
+        speed: 20000,         // Duration of the entire loop transition (e.g., 8 seconds)
         autoplay: {
           delay: 0,          // Start scrolling immediately
           disableOnInteraction: false,


### PR DESCRIPTION
- I increased the Swiper speed parameter from 8000 to 20000 in Index.html to slow down the testimonial rotation.
- I verified that testimonial quotes are correctly using Tailwind CSS classes (e.g., leading-relaxed) to ensure they display as paragraphs. No changes to formatting were required as it was already correctly implemented.