### PR TITLE
Fix: Refine tech logo animation for seamless loop and even spacing

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -104,8 +104,15 @@
     }
 
     .tech-logo-row .tech-logo {
-      margin-right: 32px; /* Equivalent to gap-8 */
-      flex-shrink: 0; /* Prevent logos from shrinking */
+      /* Existing styles */
+      margin-right: 32px;
+      flex-shrink: 0;
+
+      /* New/updated styles for consistency */
+      box-sizing: border-box; /* Ensures padding and border are included in the element's total width and height */
+      margin-left: 0;
+      margin-top: 0;
+      margin-bottom: 0;
     }
 
     @keyframes scroll-left {


### PR DESCRIPTION
- I ensured consistent sizing and margins for individual tech logos using `box-sizing: border-box` and resetting extraneous margins. This helps in achieving more predictable widths for animation calculations.
- I relied on `width: fit-content` for logo rows and `translateX(-50%)` in keyframes, which should provide a seamless loop with duplicated content if item widths are consistent.
- These changes aim to improve the smoothness of the loop and the visual consistency of spacing between logos.