### PR TITLE
Fix: Make technology icons static on homepage

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -290,12 +290,12 @@
 /* Apply to the specific tracks within each section */
 /* Row 1 - scrolls Right to Left */
 #logo-scroller-row1-section .ticker-track { /* Applies to both tracks in section 1 */
-  animation: ticker-ltr 60s linear infinite; /* Adjust 60s for speed */
+  /* animation: ticker-ltr 60s linear infinite; */ /* Adjust 60s for speed */
 }
 
 /* Row 2 - scrolls Left to Right */
 #logo-scroller-row2-section .ticker-track { /* Applies to both tracks in section 2 */
-  animation: ticker-rtl 60s linear infinite; /* Adjust 60s for speed */
+  /* animation: ticker-rtl 60s linear infinite; */ /* Adjust 60s for speed */
 }
   </style>
   <script type="application/ld+json">


### PR DESCRIPTION
I removed the CSS animations that caused the technology icons in the 'Technologies Section' to scroll horizontally.

- I commented out the `animation` property for `#logo-scroller-row1-section .ticker-track` and `#logo-scroller-row2-section .ticker-track` in `Index.html`.
- I verified that the corresponding JavaScript animation code was already commented out.

This change ensures the technology icons are displayed statically as per your requirement.