### PR TITLE
Feat: Implement responsive layout for technology logos

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -102,6 +102,7 @@
       display: flex;
       width: 100%; /* Changed from max-content */
       justify-content: center; /* Added */
+      flex-wrap: wrap; /* Added */
     }
 
     .tech-logo-row .tech-logo {
@@ -267,6 +268,31 @@
 
 #logo-scroller-row2-section .ticker-track { /* Applies to both tracks in section 2 */
 }
+
+        /* Responsive adjustments for tech logos */
+        @media (max-width: 768px) { /* Tablet breakpoint */
+          .tech-logo-row .tech-logo {
+            margin-right: 32px; /* Reduce margin for tablets */
+            margin-bottom: 20px; /* Add some bottom margin if they wrap */
+          }
+          /* Adjust the last logo in a row to not have excessive margin if centered */
+          .tech-logo-row .tech-logo:last-child {
+            margin-right: 0; /* Or adjust as needed if centering handles it */
+          }
+        }
+
+        @media (max-width: 480px) { /* Mobile breakpoint */
+          .tech-logo-row .tech-logo {
+            margin-right: 16px; /* Further reduce margin for mobiles */
+            margin-left: 16px; /* Add some left margin for better centering feel when wrapped */
+            margin-bottom: 16px; /* Adjust bottom margin */
+          }
+           /* Ensure even spacing for mobile when wrapped and centered */
+          .tech-logo-row {
+            padding-left: 16px; /* Add some padding to the row itself */
+            padding-right: 16px;
+          }
+        }
   </style>
   <script type="application/ld+json">
     {


### PR DESCRIPTION
I've made the technology logos section responsive for tablet and mobile views.

- I added `flex-wrap: wrap` to `.tech-logo-row` in `Index.html` to allow logos to wrap on smaller screens.
- I introduced media queries to adjust margins for `.tech-logo` at tablet (max-width: 768px) and mobile (max-width: 480px) breakpoints:
    - Reduced `margin-right` for better spacing.
    - Added `margin-bottom` for wrapped items.
    - Added `margin-left` for `.tech-logo` and horizontal padding for `.tech-logo-row` on mobile for improved centering and spacing.
- The `.tech-logo-row .tech-logo:last-child { margin-right: 0; }` rule was added for tablet view to manage spacing of the last item in a potentially wrapped row.

These changes ensure that the technology logos are displayed appropriately across different device screen sizes, improving your experience on mobile and tablet.