### PR TITLE
Feat: Make service details on services.html always visible

### DIFF
--- a/services.html
+++ b/services.html
@@ -242,16 +242,15 @@
 
                 <!-- Virtual Assistance -->
                 <div id="virtual-assistance" class="bg-white rounded-xl shadow-lg overflow-hidden" data-aos="fade-up" data-aos-delay="100">
-                    <button aria-expanded="false" aria-controls="va-details" class="w-full p-6 text-left focus:outline-none focus:bg-gray-100 hover:bg-gray-50 transition duration-150 ease-in-out">
+                    <div class="p-6">
                         <div class="flex items-center">
                             <span class="bg-blue-100 p-3 rounded-full mr-4">
                                 <i class="fas fa-headset text-blue-600 text-2xl"></i>
                             </span>
                             <h3 class="text-2xl font-semibold text-gray-800 hover:text-blue-600">Virtual Assistance</h3>
-                            <i class="fas fa-chevron-down ml-auto text-gray-500 transform transition-transform duration-300"></i>
                         </div>
-                    </button>
-                    <div id="va-details" class="hidden p-6 border-t border-gray-200 bg-gray-50">
+                    </div>
+                    <div id="va-details" class="p-6 border-t border-gray-200 bg-gray-50">
                         <p class="text-gray-700 mb-4">We will provide dedicated virtual assistants who will handle a wide range of administrative and operational tasks—allowing you to focus on strategy and growth. Our virtual assistants will manage calendars, schedule meetings, handle email correspondence, conduct online research, and support day-to-day project coordination. Each virtual assistant will undergo rigorous training and will adapt quickly to your unique processes and preferred tools.</p>
                         <h4 class="text-lg font-semibold text-gray-700 mb-2">Common Tools Used:</h4>
                         <ul class="list-disc list-inside text-gray-600 space-y-1 mb-4 pl-4">
@@ -270,16 +269,15 @@
 
                 <!-- Software Development -->
                 <div id="software-development" class="bg-white rounded-xl shadow-lg overflow-hidden" data-aos="fade-up" data-aos-delay="200">
-                    <button aria-expanded="false" aria-controls="dev-details" class="w-full p-6 text-left focus:outline-none focus:bg-gray-100 hover:bg-gray-50 transition duration-150 ease-in-out">
+                    <div class="p-6">
                         <div class="flex items-center">
                             <span class="bg-blue-100 p-3 rounded-full mr-4">
                                 <i class="fas fa-code text-blue-600 text-2xl"></i>
                             </span>
                             <h3 class="text-2xl font-semibold text-gray-800 hover:text-blue-600">Software Development</h3>
-                            <i class="fas fa-chevron-down ml-auto text-gray-500 transform transition-transform duration-300"></i>
                         </div>
-                    </button>
-                    <div id="dev-details" class="hidden p-6 border-t border-gray-200 bg-gray-50">
+                    </div>
+                    <div id="dev-details" class="p-6 border-t border-gray-200 bg-gray-50">
                         <p class="text-gray-700 mb-4">Our software development teams will build, maintain, and scale web and mobile applications according to your specifications. Whether you require a customer-facing portal, an internal dashboard, or a full-featured mobile app, we will design, code, and deploy solutions aligned with industry best practices. All developers will be versed in agile methodologies and will collaborate closely with your product managers to ensure rapid iterations and robust code quality.</p>
                         <h4 class="text-lg font-semibold text-gray-700 mt-4 mb-1">Pricing:</h4>
                         <p class="text-gray-600">Please contact us for a personalized quote tailored to your project scope and requirements.</p>
@@ -289,16 +287,15 @@
 
                 <!-- Custom BPO Services -->
                 <div id="bpo-services" class="bg-white rounded-xl shadow-lg overflow-hidden" data-aos="fade-up" data-aos-delay="300">
-                    <button aria-expanded="false" aria-controls="bpo-details" class="w-full p-6 text-left focus:outline-none focus:bg-gray-100 hover:bg-gray-50 transition duration-150 ease-in-out">
+                    <div class="p-6">
                         <div class="flex items-center">
                             <span class="bg-blue-100 p-3 rounded-full mr-4">
                                 <i class="fas fa-people-arrows text-blue-600 text-2xl"></i>
                             </span>
                             <h3 class="text-2xl font-semibold text-gray-800 hover:text-blue-600">Custom BPO Services</h3>
-                            <i class="fas fa-chevron-down ml-auto text-gray-500 transform transition-transform duration-300"></i>
                         </div>
-                    </button>
-                    <div id="bpo-details" class="hidden p-6 border-t border-gray-200 bg-gray-50">
+                    </div>
+                    <div id="bpo-details" class="p-6 border-t border-gray-200 bg-gray-50">
                         <p class="text-gray-700 mb-4">Our custom services offering will address any specialized business process or bespoke project requirement you may have. Whether you need workflow automation, specialized data entry, market research, or a unique combination of multiple services, we will assemble a dedicated team tailored to your exact needs. Every custom engagement will begin with a discovery phase to map out requirements, followed by a scalable execution plan.</p>
                         <h4 class="text-lg font-semibold text-gray-700 mt-4 mb-1">Pricing:</h4>
                         <p class="text-gray-600">Please contact us for a personalized quote for your custom service needs.</p>
@@ -307,16 +304,15 @@
                 </div>
                  <!-- Placeholder for Custom Solutions - if different from Custom BPO -->
                 <div id="custom-solutions" class="bg-white rounded-xl shadow-lg overflow-hidden" data-aos="fade-up" data-aos-delay="400">
-                    <button aria-expanded="false" aria-controls="cs-details" class="w-full p-6 text-left focus:outline-none focus:bg-gray-100 hover:bg-gray-50 transition duration-150 ease-in-out">
+                    <div class="p-6">
                         <div class="flex items-center">
                             <span class="bg-blue-100 p-3 rounded-full mr-4">
                                 <i class="fas fa-lightbulb text-blue-600 text-2xl"></i>
                             </span>
                             <h3 class="text-2xl font-semibold text-gray-800 hover:text-blue-600">Tailored Solutions & Consulting</h3>
-                            <i class="fas fa-chevron-down ml-auto text-gray-500 transform transition-transform duration-300"></i>
                         </div>
-                    </button>
-                    <div id="cs-details" class="hidden p-6 border-t border-gray-200 bg-gray-50">
+                    </div>
+                    <div id="cs-details" class="p-6 border-t border-gray-200 bg-gray-50">
                         <p class="text-gray-700 mb-4">Beyond our standard service categories, we offer specialized consulting and tailored solutions. If you have a unique challenge or require a multi-faceted approach that combines various aspects of our expertise, we're here to build that with you. This can include process optimization consulting, setting up remote teams with specific skill sets, or project-based strategic support.</p>
                         <h4 class="text-lg font-semibold text-gray-700 mt-4 mb-1">Pricing:</h4>
                         <p class="text-gray-600">Let's discuss your unique requirements to build a custom quote.</p>
@@ -434,59 +430,6 @@
     </script>
 
   <!-- Accordion Script -->
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      const accordionButtons = document.querySelectorAll('button[aria-expanded][aria-controls]');
-
-      accordionButtons.forEach(button => {
-        button.addEventListener('click', function () {
-          const currentlyExpanded = this.getAttribute('aria-expanded') === 'true';
-          const controlsId = this.getAttribute('aria-controls');
-          const detailsPanel = document.getElementById(controlsId);
-          const chevronIcon = this.querySelector('.fa-chevron-down, .fa-chevron-up');
-
-          // Behavior: Close others when one is opened
-          if (!currentlyExpanded) { // If we are about to open this one
-            accordionButtons.forEach(otherButton => {
-              if (otherButton !== this) {
-                otherButton.setAttribute('aria-expanded', 'false');
-                const otherDetailsPanelId = otherButton.getAttribute('aria-controls');
-                const otherDetailsPanel = document.getElementById(otherDetailsPanelId);
-                if (otherDetailsPanel) {
-                  otherDetailsPanel.classList.add('hidden');
-                }
-                const otherChevronIcon = otherButton.querySelector('.fa-chevron-down, .fa-chevron-up');
-                if (otherChevronIcon) {
-                  otherChevronIcon.classList.remove('fa-chevron-up');
-                  otherChevronIcon.classList.add('fa-chevron-down');
-                }
-              }
-            });
-          }
-
-          // Toggle the clicked accordion
-          if (detailsPanel) {
-            if (currentlyExpanded) {
-              this.setAttribute('aria-expanded', 'false');
-              detailsPanel.classList.add('hidden');
-              if (chevronIcon) {
-                chevronIcon.classList.remove('fa-chevron-up');
-                chevronIcon.classList.add('fa-chevron-down');
-              }
-            } else {
-              this.setAttribute('aria-expanded', 'true');
-              detailsPanel.classList.remove('hidden');
-              if (chevronIcon) {
-                chevronIcon.classList.remove('fa-chevron-down');
-                chevronIcon.classList.add('fa-chevron-up');
-              }
-            }
-          }
-        });
-      });
-    });
-  </script>
-
   <!-- AOS and other scripts -->
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>


### PR DESCRIPTION
I modified `services.html` to display all service details by default, removing the previous accordion-style layout.

- I replaced accordion toggle buttons with static header elements for each service.
- I removed the `hidden` class from service detail content divs.
- I deleted the JavaScript responsible for accordion functionality.
- I removed chevron icons from service headers as they are no longer expandable/collapsible.

This change makes service information more immediately accessible to you, per the request to have services presented "in your face".