### PR TITLE
Feat: Apply creative enhancements to career detail pages

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -264,9 +264,11 @@
 
 /* Apply to the specific tracks within each section */
 #logo-scroller-row1-section .ticker-track { /* Applies to both tracks in section 1 */
+  /* animation: ticker-ltr 60s linear infinite; */
 }
 
 #logo-scroller-row2-section .ticker-track { /* Applies to both tracks in section 2 */
+  /* animation: ticker-rtl 60s linear infinite; */
 }
 
         /* Responsive adjustments for tech logos */

--- a/careers/business-analyst.html
+++ b/careers/business-analyst.html
@@ -154,9 +154,10 @@
                 <p class="text-gray-700 leading-relaxed">
                     We are seeking an analytical and detail-oriented Business Analyst to bridge the gap between business needs and technology solutions.
                 </p>
-                <blockquote class="my-4 pl-4 py-2 border-l-4 border-blue-500 italic text-gray-600 bg-blue-50 rounded-r-md">
-                    The ideal candidate will possess strong problem-solving skills, be adept at requirements gathering, and excel in process improvement.
-                </blockquote>
+       <blockquote class="my-4 pl-4 pr-4 py-3 border-l-4 border-yellow-400 bg-yellow-50 rounded-r-md flex text-gray-700">
+           <i class="fas fa-quote-left text-yellow-500 mr-3 text-lg mt-1"></i>
+           <p class="m-0">The ideal candidate will possess strong problem-solving skills, be adept at requirements gathering, and excel in process improvement.</p>
+       </blockquote>
             </section>
 
             <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
@@ -164,31 +165,31 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
@@ -200,37 +201,37 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
@@ -242,19 +243,19 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
@@ -266,31 +267,31 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Business Analyst role.</span>
                     </li>

--- a/careers/customer-support-specialist.html
+++ b/careers/customer-support-specialist.html
@@ -154,9 +154,10 @@
                 <p class="text-gray-700 leading-relaxed">
                     We are looking for a patient, empathetic, and communicative Customer Support Specialist to assist our clients' customers.
                 </p>
-                <blockquote class="my-4 pl-4 py-2 border-l-4 border-blue-500 italic text-gray-600 bg-blue-50 rounded-r-md">
-                    The ideal candidate is passionate about customer satisfaction and can resolve issues effectively and efficiently.
-                </blockquote>
+       <blockquote class="my-4 pl-4 pr-4 py-3 border-l-4 border-yellow-400 bg-yellow-50 rounded-r-md flex text-gray-700">
+           <i class="fas fa-quote-left text-yellow-500 mr-3 text-lg mt-1"></i>
+           <p class="m-0">The ideal candidate is passionate about customer satisfaction and can resolve issues effectively and efficiently.</p>
+       </blockquote>
             </section>
 
             <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
@@ -164,31 +165,31 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
@@ -200,37 +201,37 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
@@ -242,19 +243,19 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
@@ -266,31 +267,31 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Customer Support Specialist role.</span>
                     </li>

--- a/careers/full-stack-developer.html
+++ b/careers/full-stack-developer.html
@@ -154,9 +154,10 @@
                 <p class="text-gray-700 leading-relaxed">
                     We are seeking a skilled Full-Stack Developer to design, develop, and maintain both front-end and back-end components of web applications.
                 </p>
-                <blockquote class="my-4 pl-4 py-2 border-l-4 border-blue-500 italic text-gray-600 bg-blue-50 rounded-r-md">
-                    The ideal candidate is proficient in multiple programming languages and frameworks, and passionate about building high-quality, scalable software.
-                </blockquote>
+       <blockquote class="my-4 pl-4 pr-4 py-3 border-l-4 border-yellow-400 bg-yellow-50 rounded-r-md flex text-gray-700">
+           <i class="fas fa-quote-left text-yellow-500 mr-3 text-lg mt-1"></i>
+           <p class="m-0">The ideal candidate is proficient in multiple programming languages and frameworks, and passionate about building high-quality, scalable software.</p>
+       </blockquote>
             </section>
 
             <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
@@ -164,31 +165,31 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
@@ -200,37 +201,37 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
@@ -242,19 +243,19 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
@@ -266,31 +267,31 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for Full-Stack Developer role.</span>
                     </li>

--- a/careers/ui-ux-designer.html
+++ b/careers/ui-ux-designer.html
@@ -154,9 +154,10 @@
                 <p class="text-gray-700 leading-relaxed">
                     We are looking for a creative and detail-oriented UI/UX Designer to design intuitive and engaging user experiences for web and mobile applications.
                 </p>
-                <blockquote class="my-4 pl-4 py-2 border-l-4 border-blue-500 italic text-gray-600 bg-blue-50 rounded-r-md">
-                    The ideal candidate has a strong portfolio showcasing user-centered design principles and a passion for creating visually appealing and functional interfaces.
-                </blockquote>
+       <blockquote class="my-4 pl-4 pr-4 py-3 border-l-4 border-yellow-400 bg-yellow-50 rounded-r-md flex text-gray-700">
+           <i class="fas fa-quote-left text-yellow-500 mr-3 text-lg mt-1"></i>
+           <p class="m-0">The ideal candidate has a strong portfolio showcasing user-centered design principles and a passion for creating visually appealing and functional interfaces.</p>
+       </blockquote>
             </section>
 
             <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
@@ -164,31 +165,31 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
@@ -200,37 +201,37 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
@@ -242,19 +243,19 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
@@ -266,31 +267,31 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>
                     <li class="flex items-start p-2 rounded-md transition-all duration-150 ease-in-out hover:bg-blue-100 hover:shadow-sm">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Placeholder item for UI/UX Designer role.</span>
                     </li>

--- a/careers/virtual-assistant.html
+++ b/careers/virtual-assistant.html
@@ -149,46 +149,47 @@
                 Location: Addis Ababa, Ethiopia - Remote Friendly | Job Type: Full-time
             </p>
 
-            <section class="mb-8" data-aos="fade-up" data-aos-delay="200">
-                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Role Overview</h2>
-                <p class="text-gray-700 leading-relaxed">
-                    We are seeking a highly organized and proactive Virtual Assistant to provide comprehensive administrative, technical, and creative assistance to our clients.
-                </p>
-                <blockquote class="my-4 pl-4 py-2 border-l-4 border-blue-500 italic text-gray-600 bg-blue-50 rounded-r-md">
-                    The ideal candidate will be a master of multitasking, possess excellent communication skills, and thrive in a remote work environment, helping clients achieve their business goals efficiently.
-                </blockquote>
-            </section>
+   <section class="mb-8" data-aos="fade-up" data-aos-delay="200">
+       <h2 class="text-2xl font-semibold text-gray-800 mb-3">Role Overview</h2>
+       <p class="text-gray-700 leading-relaxed">
+           We are seeking a highly organized and proactive Virtual Assistant to provide comprehensive administrative, technical, and creative assistance to our clients.
+       </p>
+       <blockquote class="my-4 pl-4 pr-4 py-3 border-l-4 border-yellow-400 bg-yellow-50 rounded-r-md flex text-gray-700">
+           <i class="fas fa-quote-left text-yellow-500 mr-3 text-lg mt-1"></i>
+           <p class="m-0">The ideal candidate will be a master of multitasking, possess excellent communication skills, and thrive in a remote work environment, helping clients achieve their business goals efficiently.</p>
+       </blockquote>
+   </section>
 
             <section class="mb-8" data-aos="fade-up" data-aos-delay="300">
                 <h2 class="text-2xl font-semibold text-gray-800 mb-3">Key Responsibilities</h2>
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Manage email correspondence, calendars, and schedule appointments.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Perform data entry, document preparation, and file management.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Conduct online research and compile information as requested.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Provide customer service support via email, chat, or phone.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-tasks"></i>
                         </span>
                         <span>Assist with social media management and content creation tasks.</span>
                     </li>
@@ -200,37 +201,37 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Proven experience as a Virtual Assistant or relevant administrative role.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Excellent written and verbal communication skills in English.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Proficiency in MS Office Suite (Word, Excel, PowerPoint) and Google Workspace.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Strong organizational and time-management skills.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>Ability to work independently and manage multiple tasks simultaneously.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-star"></i>
                         </span>
                         <span>High-speed internet access and a quiet work environment.</span>
                     </li>
@@ -242,19 +243,19 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Experience with project management tools (e.g., Asana, Trello).</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Familiarity with CRM software (e.g., HubSpot, Salesforce).</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-plus-circle"></i>
                         </span>
                         <span>Basic graphic design or video editing skills.</span>
                     </li>
@@ -266,31 +267,31 @@
                 <ul class="text-gray-700 space-y-2 leading-relaxed md:grid md:grid-cols-2 md:gap-x-8">
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Competitive salary based on experience and skills.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Flexible work hours and remote work opportunities.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Opportunities for professional development and skills training.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>A collaborative, supportive, and dynamic team environment.</span>
                     </li>
                     <li class="flex items-start">
                         <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                            <i class="fas fa-check-circle"></i>
+                            <i class="fas fa-gift"></i>
                         </span>
                         <span>Chance to work with diverse clients and challenging projects.</span>
                     </li>


### PR DESCRIPTION
I've further enhanced the visual presentation of individual career detail pages (careers/*.html):

- Varied list icons:
    - Key Responsibilities lists now use 'fas fa-tasks'.
    - Required Qualifications lists now use 'fas fa-star'.
    - Preferred Qualifications lists now use 'fas fa-plus-circle'.
    - What We Offer (Benefits) lists now use 'fas fa-gift'. This provides better visual cues for different types of information.

- Restyled blockquote in "Role Overview":
    - Changed styling to a non-italic, yellow-themed block (bg-yellow-50, border-yellow-400).
    - Prepended a 'fas fa-quote-left' icon for visual emphasis.

These changes were applied consistently across all five career detail pages to improve visual appeal and reduce redundancy in styling.