### PR TITLE
Style: Apply alternating section backgrounds site-wide

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -507,7 +507,7 @@
     </section>
 
     <!-- Why Choose Us Section -->
-    <section id="why-us" class="py-28 bg-gray-50">
+    <section id="why-us" class="py-28 bg-gray-100">
         <div class="container mx-auto px-6">
             <div class="flex flex-col md:flex-row items-center">
                 <div class="md:w-1/2 mb-12 md:mb-0 md:pr-12" data-aos="fade-up"  data-aos-duration="600"  data-aos-offset="100"  data-aos-easing="ease-out-cubic">
@@ -642,7 +642,7 @@
     </section>
 
     <!-- Careers Section -->
-    <section id="careers" class="py-28 bg-white">
+    <section id="careers" class="py-28 bg-gray-100">
         <div class="container mx-auto px-6">
             <div class="text-center mb-16" data-aos="fade-up" data-aos-duration="600" data-aos-offset="100" data-aos-easing="ease-out-cubic">
                 <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-8">Join Our <span class="text-blue-600">Team</span></h2>
@@ -774,7 +774,7 @@
     </section>
 
     <!-- Blog Preview Section -->
-    <section id="blog" class="py-28 bg-gray-50">
+    <section id="blog" class="py-28 bg-white">
         <div class="container mx-auto px-6">
             <div class="text-center mb-16" data-aos="fade-up" data-aos-duration="600" data-aos-offset="100" data-aos-easing="ease-out-cubic">
                 <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-8">From Our <span class="text-blue-600">Blog</span></h2>

--- a/about.html
+++ b/about.html
@@ -249,7 +249,7 @@
                 </div>
             </section>
 
-            <section class="mb-12 md:mb-16">
+            <section class="mb-12 md:mb-16 bg-gray-100 py-12 md:py-16">
                 <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-6 text-center" data-aos="fade-up">Our Journey</h2>
                 <div class="max-w-3xl mx-auto text-lg text-gray-700"> <!-- Removed data-aos-delay from here, will be on individual cards -->
                     <div class="bg-blue-50 p-6 rounded-lg shadow-md mb-6" data-aos="fade-up" data-aos-delay="100">
@@ -321,7 +321,7 @@
                 </div>
             </section>
 
-            <section class="mb-12 md:mb-16">
+            <section class="mb-12 md:mb-16 bg-gray-100 py-12 md:py-16">
                 <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mt-12 mb-8 text-center" data-aos="fade-up">Why Partner With Bridgee?</h2>
                 <div class="grid md:grid-cols-2 gap-x-8 gap-y-6">
                     <div class="flex items-start p-4 rounded-lg hover:shadow-lg transition-shadow duration-300" data-aos="fade-up" data-aos-delay="100">

--- a/careers.html
+++ b/careers.html
@@ -233,7 +233,7 @@
    </section>
 
     <!-- Section: Perks & Benefits -->
-    <section class="py-12 md:py-16 bg-white"> <!-- Or bg-gray-50 if alternating pattern is desired -->
+    <section class="py-12 md:py-16 bg-gray-100"> <!-- Or bg-gray-50 if alternating pattern is desired -->
         <div class="container mx-auto px-6">
             <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-10 text-center" data-aos="fade-up">
                 Perks & <span class="text-blue-600">Benefits</span>
@@ -396,8 +396,48 @@
             </div>
         </section>
 
-            </div>
-        </section>
+   <!-- Section: Our Hiring Process -->
+   <section class="py-12 md:py-16 bg-gray-100"> <!-- Ensure this is bg-gray-100 -->
+       <div class="container mx-auto px-6">
+           <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-10 text-center" data-aos="fade-up">
+               Our Hiring <span class="text-blue-600">Process</span>
+           </h2>
+           <div class="max-w-4xl mx-auto grid md:grid-cols-4 gap-8 text-center">
+               <!-- Step 1 -->
+               <div class="flex flex-col items-center p-4" data-aos="fade-up" data-aos-delay="100">
+                   <div class="bg-white p-4 rounded-full shadow-md mb-3">
+                       <i class="fas fa-file-alt text-3xl text-blue-500"></i>
+                   </div>
+                   <h4 class="text-lg font-semibold text-gray-700 mb-1">1. Apply Online</h4>
+                   <p class="text-gray-600 text-sm">Submit your application through our careers portal or via email for open positions.</p>
+               </div>
+               <!-- Step 2 -->
+               <div class="flex flex-col items-center p-4" data-aos="fade-up" data-aos-delay="200">
+                   <div class="bg-white p-4 rounded-full shadow-md mb-3">
+                       <i class="fas fa-search text-3xl text-blue-500"></i>
+                   </div>
+                   <h4 class="text-lg font-semibold text-gray-700 mb-1">2. Initial Screening</h4>
+                   <p class="text-gray-600 text-sm">Our HR team reviews your application to match your skills and experience with role requirements.</p>
+               </div>
+               <!-- Step 3 -->
+               <div class="flex flex-col items-center p-4" data-aos="fade-up" data-aos-delay="300">
+                   <div class="bg-white p-4 rounded-full shadow-md mb-3">
+                       <i class="fas fa-comments text-3xl text-blue-500"></i>
+                   </div>
+                   <h4 class="text-lg font-semibold text-gray-700 mb-1">3. Interview(s)</h4>
+                   <p class="text-gray-600 text-sm">Selected candidates are invited for one or more interviews with our team.</p>
+               </div>
+               <!-- Step 4 -->
+               <div class="flex flex-col items-center p-4" data-aos="fade-up" data-aos-delay="400">
+                   <div class="bg-white p-4 rounded-full shadow-md mb-3">
+                       <i class="fas fa-handshake text-3xl text-blue-500"></i>
+                   </div>
+                   <h4 class="text-lg font-semibold text-gray-700 mb-1">4. Offer</h4>
+                   <p class="text-gray-600 text-sm">Successful candidates receive a job offer to join Bridgee Solutions.</p>
+               </div>
+           </div>
+       </div>
+   </section>
 
     </main>
 


### PR DESCRIPTION
I've standardized the use of alternating background colors (primarily bg-white and bg-gray-100) for major content sections across key pages to improve visual rhythm and content separation.

Affected pages:
- Index.html: I applied alternating bg-white and bg-gray-100 to main content sections.
- services.html: I reviewed and confirmed its existing alternating background pattern is suitable.
- about.html: I applied alternating bg-white and bg-gray-100 to sections within its main content wrapper.
- contact.html: I reviewed and confirmed its card-based design is appropriate; no changes made for this pattern.
- careers.html (main page): I ensured a consistent alternating pattern, re-adding the 'Our Hiring Process' section with the correct bg-gray-100 and confirming 'Perks & Benefits' also uses bg-gray-100.

Special sections like page headers with gradients or distinct accent colors (e.g., bg-blue-50, bg-blue-600) were generally preserved.