### PR TITLE
Revert: Revert "Style: Apply alternating section backgrounds site-wide"

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -118,6 +118,33 @@
     }
 
     /* Keyframes and animation application removed for JS driven animation */
+    /*
+    @keyframes scroll-left {
+      0% {
+        transform: translateX(0%);
+      }
+      100% {
+        transform: translateX(-50%);
+      }
+    }
+
+    @keyframes scroll-right {
+      0% {
+        transform: translateX(-50%);
+      }
+      100% {
+        transform: translateX(0%);
+      }
+    }
+
+    #tech-logo-row-1 {
+      animation: scroll-left 80s linear infinite;
+    }
+
+    #tech-logo-row-2 {
+      animation: scroll-right 80s linear infinite;
+    }
+    */
 
     .testimonial-swiper {
       position: relative; /* Ensure it's a positioning context for absolute arrows */
@@ -263,38 +290,15 @@
 }
 
 /* Apply to the specific tracks within each section */
+/* Row 1 - scrolls Right to Left */
 #logo-scroller-row1-section .ticker-track { /* Applies to both tracks in section 1 */
-  /* animation: ticker-ltr 60s linear infinite; */
+  /* animation: ticker-ltr 60s linear infinite; */ /* Adjust 60s for speed */
 }
 
+/* Row 2 - scrolls Left to Right */
 #logo-scroller-row2-section .ticker-track { /* Applies to both tracks in section 2 */
-  /* animation: ticker-rtl 60s linear infinite; */
+  /* animation: ticker-rtl 60s linear infinite; */ /* Adjust 60s for speed */
 }
-
-        /* Responsive adjustments for tech logos */
-        @media (max-width: 768px) { /* Tablet breakpoint */
-          .tech-logo-row .tech-logo {
-            margin-right: 32px; /* Reduce margin for tablets */
-            margin-bottom: 20px; /* Add some bottom margin if they wrap */
-          }
-          /* Adjust the last logo in a row to not have excessive margin if centered */
-          .tech-logo-row .tech-logo:last-child {
-            margin-right: 0; /* Or adjust as needed if centering handles it */
-          }
-        }
-
-        @media (max-width: 480px) { /* Mobile breakpoint */
-          .tech-logo-row .tech-logo {
-            margin-right: 16px; /* Further reduce margin for mobiles */
-            margin-left: 16px; /* Add some left margin for better centering feel when wrapped */
-            margin-bottom: 16px; /* Adjust bottom margin */
-          }
-           /* Ensure even spacing for mobile when wrapped and centered */
-          .tech-logo-row {
-            padding-left: 16px; /* Add some padding to the row itself */
-            padding-right: 16px;
-          }
-        }
   </style>
   <script type="application/ld+json">
     {
@@ -507,7 +511,7 @@
     </section>
 
     <!-- Why Choose Us Section -->
-    <section id="why-us" class="py-28 bg-gray-100">
+    <section id="why-us" class="py-28 bg-gray-50">
         <div class="container mx-auto px-6">
             <div class="flex flex-col md:flex-row items-center">
                 <div class="md:w-1/2 mb-12 md:mb-0 md:pr-12" data-aos="fade-up"  data-aos-duration="600"  data-aos-offset="100"  data-aos-easing="ease-out-cubic">
@@ -642,7 +646,7 @@
     </section>
 
     <!-- Careers Section -->
-    <section id="careers" class="py-28 bg-gray-100">
+    <section id="careers" class="py-28 bg-white">
         <div class="container mx-auto px-6">
             <div class="text-center mb-16" data-aos="fade-up" data-aos-duration="600" data-aos-offset="100" data-aos-easing="ease-out-cubic">
                 <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-8">Join Our <span class="text-blue-600">Team</span></h2>
@@ -774,7 +778,7 @@
     </section>
 
     <!-- Blog Preview Section -->
-    <section id="blog" class="py-28 bg-white">
+    <section id="blog" class="py-28 bg-gray-50">
         <div class="container mx-auto px-6">
             <div class="text-center mb-16" data-aos="fade-up" data-aos-duration="600" data-aos-offset="100" data-aos-easing="ease-out-cubic">
                 <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-8">From Our <span class="text-blue-600">Blog</span></h2>
@@ -918,6 +922,77 @@
     
     // Testimonial Swiper Initialization & Logo Scroller
     document.addEventListener('DOMContentLoaded', function () {
+      // Logo Scroller (JS Animation - to be removed or commented out)
+      // console.log("DOM fully loaded and parsed. Initializing logo scroller.");
+      /*
+      function animateLogoRow(rowId, scrollSpeedPxPerFrame, moveContentRightToLeft) {
+        const rowElement = document.getElementById(rowId);
+        if (!rowElement) {
+          console.error(`Logo row not found: ${rowId}`);
+          return;
+        }
+        // console.log(`Initializing animation for ${rowId}. Speed: ${scrollSpeedPxPerFrame}, RTL: ${moveContentRightToLeft}`);
+
+        if (rowElement.children.length === 0) {
+            // console.error(`No logos found in ${rowId} to animate at outset.`);
+            return;
+        }
+
+        const originalLogos = Array.from(rowElement.children);
+
+        let calculatedWidthOfOneSet = 0;
+        const logoMarginRight = 64;
+
+        originalLogos.forEach(logo => {
+          calculatedWidthOfOneSet += logo.offsetWidth + logoMarginRight;
+        });
+
+        // console.log(`${rowId} - Calculated width of ONE set (logos + margins): ${calculatedWidthOfOneSet}px`);
+
+        originalLogos.forEach(logo => {
+          rowElement.appendChild(logo.cloneNode(true));
+        });
+
+        void rowElement.offsetWidth;
+
+        const scrollWidthOfOneSet = calculatedWidthOfOneSet;
+
+        let currentPositionDotPx = 0;
+
+        if (scrollWidthOfOneSet === 0) {
+            // console.error(`${rowId} - scrollWidthOfOneSet is 0. Animation cannot proceed meaningfully.`);
+            return;
+        } else {
+            // console.log(`${rowId} - USING scrollWidthOfOneSet for animation: ${scrollWidthOfOneSet}px`);
+        }
+
+        if (!moveContentRightToLeft) {
+            rowElement.style.transform = `translateX(-${scrollWidthOfOneSet}px)`;
+            // console.log(`${rowId} - Initial LTR transform set to: translateX(-${scrollWidthOfOneSet}px)`);
+        }
+
+        function step() {
+          currentPositionDotPx += scrollSpeedPxPerFrame;
+
+          if (currentPositionDotPx >= scrollWidthOfOneSet) {
+            currentPositionDotPx -= scrollWidthOfOneSet;
+          }
+
+          if (moveContentRightToLeft) {
+            rowElement.style.transform = `translateX(-${currentPositionDotPx}px)`;
+          } else {
+            rowElement.style.transform = `translateX(${currentPositionDotPx - scrollWidthOfOneSet}px)`;
+          }
+          requestAnimationFrame(step);
+        }
+
+        // console.log(`Starting animation loop for ${rowId}`);
+        requestAnimationFrame(step);
+      }
+
+      // animateLogoRow('tech-logo-row-1', 0.5, true);
+      // animateLogoRow('tech-logo-row-2', 0.5, false);
+      */
 
       const testimonialSwiper = new Swiper('.testimonial-swiper', {
         loop: true,

--- a/about.html
+++ b/about.html
@@ -249,7 +249,7 @@
                 </div>
             </section>
 
-            <section class="mb-12 md:mb-16 bg-gray-100 py-12 md:py-16">
+            <section class="mb-12 md:mb-16">
                 <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-6 text-center" data-aos="fade-up">Our Journey</h2>
                 <div class="max-w-3xl mx-auto text-lg text-gray-700"> <!-- Removed data-aos-delay from here, will be on individual cards -->
                     <div class="bg-blue-50 p-6 rounded-lg shadow-md mb-6" data-aos="fade-up" data-aos-delay="100">
@@ -321,7 +321,7 @@
                 </div>
             </section>
 
-            <section class="mb-12 md:mb-16 bg-gray-100 py-12 md:py-16">
+            <section class="mb-12 md:mb-16">
                 <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mt-12 mb-8 text-center" data-aos="fade-up">Why Partner With Bridgee?</h2>
                 <div class="grid md:grid-cols-2 gap-x-8 gap-y-6">
                     <div class="flex items-start p-4 rounded-lg hover:shadow-lg transition-shadow duration-300" data-aos="fade-up" data-aos-delay="100">

--- a/careers.html
+++ b/careers.html
@@ -137,171 +137,64 @@
             </div>
         </section>
 
-   <!-- Section 2: Why Work With Us? / Our Culture & Values -->
-   <section class="py-12 md:py-16 bg-white">
-       <div class="container mx-auto px-6">
-           <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-10 text-center" data-aos="fade-up">Why Bridgee? Our <span class="text-blue-600">Culture & Values</span></h2>
-           <div class="max-w-4xl mx-auto">
-               <p class="text-lg text-gray-700" data-aos="fade-up" data-aos-delay="100"> <!-- Removed mb-6 here -->
-                   Bridgee Solutions fosters a culture centered around growth, efficiency, innovation, and client success.
-               </p>
-               <blockquote class="my-6 pl-4 py-2 border-l-4 border-blue-500 italic text-gray-600 bg-blue-50 rounded-r-md" data-aos="fade-left" data-aos-delay="120">
-                   We are more than just an outsourcing company; we aim to be a dedicated partner to our clients.
-               </blockquote>
-               <p class="text-lg text-gray-700 mb-6" data-aos="fade-up" data-aos-delay="100">
-                   Our foundation in Addis Ababa, Ethiopia, gives us access to a vibrant, educated, and motivated workforce. We are committed to:
-               </p>
-               <ul class="text-lg text-gray-700 space-y-2 mb-8 md:grid md:grid-cols-2 md:gap-x-8" data-aos="fade-up" data-aos-delay="150">
-                   <li class="flex items-start">
-                       <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                           <i class="fas fa-star"></i>
-                       </span>
-                       <span>Bridging Gaps: Connecting global businesses with exceptional Ethiopian talent.</span>
-                   </li>
-                   <li class="flex items-start">
-                       <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                           <i class="fas fa-star"></i>
-                       </span>
-                       <span>Partnership: Working as an extension of our clients' teams, fostering collaborative success.</span>
-                   </li>
-                   <li class="flex items-start">
-                       <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                           <i class="fas fa-star"></i>
-                       </span>
-                       <span>Learning & Adaptation: Continuously evolving to meet client needs and embracing market changes.</span>
-                   </li>
-                   <li class="flex items-start">
-                       <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                           <i class="fas fa-star"></i>
-                       </span>
-                       <span>Investing in Talent: Significant investment in training programs (including our comprehensive 200-hour program), technology infrastructure, and creating a supportive, growth-oriented work environment.</span>
-                   </li>
-                   <li class="flex items-start">
-                       <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                           <i class="fas fa-star"></i>
-                       </span>
-                       <span>Showcasing Ethiopian Talent: A core mission is to highlight the capabilities of our local workforce on a global stage.</span>
-                   </li>
-                   <li class="flex items-start">
-                       <span class="flex-shrink-0 w-5 h-5 mr-3 text-blue-500 pt-1">
-                           <i class="fas fa-star"></i>
-                       </span>
-                       <span>Operational Excellence & Client Success: Driven by deep expertise in operations and technology.</span>
-                   </li>
-               </ul>
+        <!-- Section 2: Why Work With Us? / Our Culture & Values -->
+        <section class="py-12 md:py-16 bg-white">
+            <div class="container mx-auto px-6">
+                <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-10 text-center" data-aos="fade-up">Why Bridgee? Our <span class="text-blue-600">Culture & Values</span></h2>
+                <div class="max-w-4xl mx-auto">
+                    <p class="text-lg text-gray-700 mb-6" data-aos="fade-up" data-aos-delay="100">
+                        Bridgee Solutions fosters a culture centered around growth, efficiency, innovation, and client success. We are more than just an outsourcing company; we aim to be a dedicated partner to our clients. Our foundation in Addis Ababa, Ethiopia, gives us access to a vibrant, educated, and motivated workforce. We are committed to:
+                    </p>
+                    <ul class="list-disc list-inside text-lg text-gray-700 space-y-2 mb-8 pl-4" data-aos="fade-up" data-aos-delay="150">
+                        <li>Bridging Gaps: Connecting global businesses with exceptional Ethiopian talent.</li>
+                        <li>Partnership: Working as an extension of our clients' teams, fostering collaborative success.</li>
+                        <li>Learning & Adaptation: Continuously evolving to meet client needs and embracing market changes.</li>
+                        <li>Investing in Talent: Significant investment in training programs (including our comprehensive 200-hour program), technology infrastructure, and creating a supportive, growth-oriented work environment.</li>
+                        <li>Showcasing Ethiopian Talent: A core mission is to highlight the capabilities of our local workforce on a global stage.</li>
+                        <li>Operational Excellence & Client Success: Driven by deep expertise in operations and technology.</li>
+                    </ul>
 
-               <h3 class="text-2xl md:text-3xl font-semibold text-gray-800 mb-6 text-center mt-12" data-aos="fade-up">Our Core Values</h3>
-               <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 text-center">
-                   <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="100">
-                       <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
-                           <i class="fas fa-handshake text-blue-600 text-3xl"></i>
-                       </div>
-                       <h4 class="text-xl font-semibold text-gray-800 mb-2">Reliability</h4>
-                       <p class="text-gray-600">We deliver consistent, high-quality services.</p>
-                   </div>
-                   <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="150">
-                       <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
-                           <i class="fas fa-lightbulb text-blue-600 text-3xl"></i>
-                       </div>
-                       <h4 class="text-xl font-semibold text-gray-800 mb-2">Innovation</h4>
-                       <p class="text-gray-600">We embrace creativity and continuous improvement.</p>
-                   </div>
-                   <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="200">
-                       <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
-                           <i class="fas fa-shield-alt text-blue-600 text-3xl"></i>
-                       </div>
-                       <h4 class="text-xl font-semibold text-gray-800 mb-2">Integrity</h4>
-                       <p class="text-gray-600">We operate with transparency and ethical practices.</p>
-                   </div>
-                   <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="250">
-                       <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
-                           <i class="fas fa-users text-blue-600 text-3xl"></i>
-                       </div>
-                       <h4 class="text-xl font-semibold text-gray-800 mb-2">Collaboration</h4>
-                       <p class="text-gray-600">We work as a true extension of your team.</p>
-                   </div>
-                   <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="300">
-                       <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
-                           <i class="fas fa-fist-raised text-blue-600 text-3xl"></i>
-                       </div>
-                       <h4 class="text-xl font-semibold text-gray-800 mb-2">Empowerment</h4>
-                       <p class="text-gray-600">We invest in our people and communities.</p>
-                   </div>
-               </div>
-           </div>
-       </div>
-   </section>
-
-    <!-- Section: Perks & Benefits -->
-    <section class="py-12 md:py-16 bg-gray-100"> <!-- Or bg-gray-50 if alternating pattern is desired -->
-        <div class="container mx-auto px-6">
-            <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-10 text-center" data-aos="fade-up">
-                Perks & <span class="text-blue-600">Benefits</span>
-            </h2>
-            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-5xl mx-auto">
-                <!-- Benefit Item 1 -->
-                <div class="flex items-start p-4" data-aos="fade-up" data-aos-delay="100">
-                    <div class="flex-shrink-0">
-                        <i class="fas fa-dollar-sign text-3xl text-blue-500 w-12 text-center"></i>
-                    </div>
-                    <div class="ml-4">
-                        <h4 class="text-lg font-semibold text-gray-700 mb-1">Competitive Salary</h4>
-                        <p class="text-gray-600 text-sm">We offer attractive compensation packages.</p>
-                    </div>
-                </div>
-                <!-- Benefit Item 2 -->
-                <div class="flex items-start p-4" data-aos="fade-up" data-aos-delay="150">
-                    <div class="flex-shrink-0">
-                        <i class="fas fa-heartbeat text-3xl text-blue-500 w-12 text-center"></i>
-                    </div>
-                    <div class="ml-4">
-                        <h4 class="text-lg font-semibold text-gray-700 mb-1">Health & Wellness</h4>
-                        <p class="text-gray-600 text-sm">Comprehensive health benefits to keep you well.</p>
-                    </div>
-                </div>
-                <!-- Benefit Item 3 -->
-                <div class="flex items-start p-4" data-aos="fade-up" data-aos-delay="200">
-                    <div class="flex-shrink-0">
-                        <i class="fas fa-graduation-cap text-3xl text-blue-500 w-12 text-center"></i>
-                    </div>
-                    <div class="ml-4">
-                        <h4 class="text-lg font-semibold text-gray-700 mb-1">Professional Development</h4>
-                        <p class="text-gray-600 text-sm">Access to training and growth opportunities (incl. our 200-hour program).</p>
-                    </div>
-                </div>
-                <!-- Benefit Item 4 -->
-                <div class="flex items-start p-4" data-aos="fade-up" data-aos-delay="250">
-                    <div class="flex-shrink-0">
-                        <i class="fas fa-users text-3xl text-blue-500 w-12 text-center"></i>
-                    </div>
-                    <div class="ml-4">
-                        <h4 class="text-lg font-semibold text-gray-700 mb-1">Supportive Team Culture</h4>
-                        <p class="text-gray-600 text-sm">Collaborate with a passionate and supportive team.</p>
-                    </div>
-                </div>
-                <!-- Benefit Item 5 -->
-                <div class="flex items-start p-4" data-aos="fade-up" data-aos-delay="300">
-                    <div class="flex-shrink-0">
-                        <i class="fas fa-briefcase text-3xl text-blue-500 w-12 text-center"></i>
-                    </div>
-                    <div class="ml-4">
-                        <h4 class="text-lg font-semibold text-gray-700 mb-1">Meaningful Work</h4>
-                        <p class="text-gray-600 text-sm">Contribute to projects that make a real impact.</p>
-                    </div>
-                </div>
-                <!-- Benefit Item 6 -->
-                <div class="flex items-start p-4" data-aos="fade-up" data-aos-delay="350">
-                    <div class="flex-shrink-0">
-                        <i class="fas fa-chart-line text-3xl text-blue-500 w-12 text-center"></i>
-                    </div>
-                    <div class="ml-4">
-                        <h4 class="text-lg font-semibold text-gray-700 mb-1">Career Growth</h4>
-                        <p class="text-gray-600 text-sm">Opportunities to advance your career within the company.</p>
+                    <h3 class="text-2xl md:text-3xl font-semibold text-gray-800 mb-6 text-center mt-12" data-aos="fade-up">Our Core Values</h3>
+                    <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 text-center">
+                        <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="100">
+                            <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
+                                <i class="fas fa-handshake text-blue-600 text-3xl"></i>
+                            </div>
+                            <h4 class="text-xl font-semibold text-gray-800 mb-2">Reliability</h4>
+                            <p class="text-gray-600">We deliver consistent, high-quality services.</p>
+                        </div>
+                        <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="150">
+                            <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
+                                <i class="fas fa-lightbulb text-blue-600 text-3xl"></i>
+                            </div>
+                            <h4 class="text-xl font-semibold text-gray-800 mb-2">Innovation</h4>
+                            <p class="text-gray-600">We embrace creativity and continuous improvement.</p>
+                        </div>
+                        <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="200">
+                            <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
+                                <i class="fas fa-shield-alt text-blue-600 text-3xl"></i>
+                            </div>
+                            <h4 class="text-xl font-semibold text-gray-800 mb-2">Integrity</h4>
+                            <p class="text-gray-600">We operate with transparency and ethical practices.</p>
+                        </div>
+                        <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="250">
+                            <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
+                                <i class="fas fa-users text-blue-600 text-3xl"></i>
+                            </div>
+                            <h4 class="text-xl font-semibold text-gray-800 mb-2">Collaboration</h4>
+                            <p class="text-gray-600">We work as a true extension of your team.</p>
+                        </div>
+                        <div class="p-6 bg-gray-50 rounded-xl shadow-lg" data-aos="fade-up" data-aos-delay="300">
+                            <div class="bg-blue-100 p-4 rounded-full inline-block mb-3">
+                                <i class="fas fa-fist-raised text-blue-600 text-3xl"></i>
+                            </div>
+                            <h4 class="text-xl font-semibold text-gray-800 mb-2">Empowerment</h4>
+                            <p class="text-gray-600">We invest in our people and communities.</p>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </section>
+        </section>
 
         <!-- Section 3: Employee Testimonials -->
         <section class="py-12 md:py-16 bg-blue-50">
@@ -324,66 +217,26 @@
                     <a href="careers/virtual-assistant.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="150">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">Virtual Assistant</h3>
                         <p class="text-gray-600 text-sm mb-3">Support clients with administrative, technical, or creative assistance remotely.</p>
-                        <p class="text-sm text-gray-500 mt-2 flex items-center">
-                            <i class="fas fa-map-marker-alt w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Addis Ababa, Ethiopia</span>
-                        </p>
-                        <p class="text-sm text-gray-500 mt-1 flex items-center">
-                            <i class="fas fa-briefcase w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Full-time</span>
-                        </p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>
                     </a>
                     <a href="careers/full-stack-developer.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="200">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">Full-Stack Developer</h3>
                         <p class="text-gray-600 text-sm mb-3">Design, develop, and maintain both front-end and back-end components of web applications.</p>
-                        <p class="text-sm text-gray-500 mt-2 flex items-center">
-                            <i class="fas fa-map-marker-alt w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Addis Ababa, Ethiopia</span>
-                        </p>
-                        <p class="text-sm text-gray-500 mt-1 flex items-center">
-                            <i class="fas fa-briefcase w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Full-time</span>
-                        </p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>
                     </a>
                     <a href="careers/customer-support-specialist.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="250">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">Customer Support Specialist</h3>
                         <p class="text-gray-600 text-sm mb-3">Provide outstanding customer service and technical support to our clients' customers.</p>
-                        <p class="text-sm text-gray-500 mt-2 flex items-center">
-                            <i class="fas fa-map-marker-alt w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Addis Ababa, Ethiopia</span>
-                        </p>
-                        <p class="text-sm text-gray-500 mt-1 flex items-center">
-                            <i class="fas fa-briefcase w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Full-time</span>
-                        </p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>
                     </a>
                     <a href="careers/ui-ux-designer.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="300">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">UI/UX Designer</h3>
                         <p class="text-gray-600 text-sm mb-3">Create intuitive, engaging, and visually appealing user interfaces and experiences for web and mobile applications.</p>
-                        <p class="text-sm text-gray-500 mt-2 flex items-center">
-                            <i class="fas fa-map-marker-alt w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Addis Ababa, Ethiopia</span>
-                        </p>
-                        <p class="text-sm text-gray-500 mt-1 flex items-center">
-                            <i class="fas fa-briefcase w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Full-time</span>
-                        </p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>
                     </a>
                     <a href="careers/business-analyst.html" class="block p-6 bg-gray-50 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" data-aos="fade-up" data-aos-delay="350">
                         <h3 class="text-xl font-semibold text-blue-700 mb-2">Business Analyst</h3>
                         <p class="text-gray-600 text-sm mb-3">Analyze business processes, identify needs, and recommend solutions to improve efficiency and outcomes.</p>
-                        <p class="text-sm text-gray-500 mt-2 flex items-center">
-                            <i class="fas fa-map-marker-alt w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Addis Ababa, Ethiopia</span>
-                        </p>
-                        <p class="text-sm text-gray-500 mt-1 flex items-center">
-                            <i class="fas fa-briefcase w-4 h-4 mr-2 text-gray-400"></i>
-                            <span>Full-time</span>
-                        </p>
                         <span class="text-sm font-medium text-blue-600 hover:underline">Learn More & Apply &rarr;</span>
                     </a>
                 </div>
@@ -397,7 +250,7 @@
         </section>
 
    <!-- Section: Our Hiring Process -->
-   <section class="py-12 md:py-16 bg-gray-100"> <!-- Ensure this is bg-gray-100 -->
+   <section class="py-12 md:py-16 bg-blue-50"> <!-- Ensure this is bg-blue-50 -->
        <div class="container mx-auto px-6">
            <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-10 text-center" data-aos="fade-up">
                Our Hiring <span class="text-blue-600">Process</span>


### PR DESCRIPTION
This commit reverts the changes made in the "Style: Apply alternating section backgrounds site-wide" commit.

- Index.html: Background colors for #why-us, #careers (on index), and #blog sections have been reverted to their original state (bg-gray-50, bg-white, bg-gray-50 respectively). Other functionalities like static/centered tech logos and disabled ticker animations are preserved.
- about.html: Removed bg-gray-100 and padding from "Our Journey" and "Why Partner With Bridgee?" sections, reverting them to display on the main white background.
- careers.html:
    - "Perks & Benefits" section background reverted to bg-white.
    - "Our Hiring Process" section (which was re-added during the reverted commit with bg-gray-100) has been ensured to be present with its original bg-blue-50 background.

This rollback restores the previous background styling for these pages.