### PR TITLE
Fix: Escape exclamation mark in static Telegram message text

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,7 @@ def escape_markdown_v2(text: str) -> str:
 async def send_telegram_notification(applicant_data, cv_filepath):
     bot = telegram.Bot(token=TELEGRAM_BOT_TOKEN)
 
-    message_text = f"📢 New Job Application Received!\n\n"
+    message_text = f"📢 New Job Application Received\!\n\n"
 
     # Escape MarkdownV2 characters for user-provided fields
     job_title = escape_markdown_v2(applicant_data.get('job_title', 'N/A'))


### PR DESCRIPTION
This commit addresses an oversight from the previous fix for MarkdownV2 character escaping in Telegram notifications.

The static introductory text "📢 New Job Application Received!" itself contained an exclamation mark which was not escaped. This caused the Telegram API to return a parsing error.

The `message_text` initialization in `app.py` has been updated to escape this exclamation mark (`Received\!`), ensuring the entire message is now correctly formatted for MarkdownV2.