### PR TITLE
Fix: Alternative asyncio event loop handling for hr_bot.py

### DIFF
--- a/hr_bot.py
+++ b/hr_bot.py
@@ -315,9 +315,35 @@ async def main():
     logger.info("HR Bot has stopped.")
 
 if __name__ == '__main__':
+    # The platform-specific policy setting (WindowsSelectorEventLoopPolicy)
+    # should remain at the TOP of the script if it was added.
+
+    loop = None  # Initialize loop to None
     try:
-        asyncio.run(main())
+        loop = asyncio.get_event_loop()
+        # If the loop is closed, try to create a new one.
+        # This can be necessary in some environments or after previous runs.
+        if loop.is_closed():
+            logger.info("Default event loop was closed, creating a new one.")
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        logger.info("Running main coroutine in the event loop.")
+        loop.run_until_complete(main())
     except KeyboardInterrupt:
         logger.info("HR Bot stopped by user.")
+    except RuntimeError as e: # Catch runtime errors specifically
+        logger.error(f"RuntimeError in main execution: {e}", exc_info=True)
+        if "Cannot close a running event loop" in str(e) or "Event loop is already running" in str(e):
+            logger.error("This might indicate an environment-specific asyncio conflict.")
     except Exception as e:
-        logger.error(f"HR Bot crashed: {e}", exc_info=True)
+        logger.error(f"HR Bot crashed with an unexpected error: {e}", exc_info=True)
+    finally:
+        # Optional: clean up the loop if it was explicitly created and is not Proactor.
+        # For ProactorEventLoop, close() can also raise "Cannot close a running event loop".
+        # Given run_polling is indefinite, explicit closing here is often problematic
+        # and best handled by the application's shutdown sequence within run_polling.
+        # if loop and not loop.is_running() and not isinstance(loop, asyncio.ProactorEventLoop):
+        #    logger.info("Closing event loop.")
+        #    loop.close()
+        logger.info("HR Bot script execution finished or was interrupted.")


### PR DESCRIPTION
This commit implements a different approach to managing the asyncio event loop in the `if __name__ == '__main__':` block of `hr_bot.py`.

Instead of directly using `asyncio.run(main())`, the new method:
- Explicitly gets the current event loop using `asyncio.get_event_loop()`.
- Checks if the loop is closed, and if so, creates and sets a new one.
- Runs the `main()` coroutine using `loop.run_until_complete(main())`.

This more explicit management can resolve certain `RuntimeError` issues related to event loops being already running or closed, especially in specific environments or when interacting with libraries that have their own strong opinions on loop management. The Windows-specific event loop policy setting remains in place.