### PR TITLE
Feat: Make "Review New Applications" menu button functional

### DIFF
--- a/hr_bot.py
+++ b/hr_bot.py
@@ -27,6 +27,8 @@ from telegram.ext import (
     CallbackQueryHandler,
     ContextTypes,
     PicklePersistence, # Optional: for simple persistence if needed later
+    MessageHandler, # Added MessageHandler
+    filters # Added filters
 )
 
 # Load environment variables from .env file
@@ -346,6 +348,12 @@ def main(): # Changed from async def
     application.add_handler(CallbackQueryHandler(button_callback_handler))
     application.add_handler(CommandHandler("start", start_command))
     application.add_handler(CommandHandler("stop", stop_command))
+
+    # Add MessageHandler for the "Review New Applications" button
+    application.add_handler(MessageHandler(
+        filters.TEXT & filters.Regex("^Review New Applications$"),
+        review_applications_command  # Point to the existing command function
+    ))
 
     logger.info("HR Bot starting...")
     application.run_polling() # Changed from await application.run_polling()


### PR DESCRIPTION
This commit updates `hr_bot.py` to make the "Review New Applications" button (from the /start command's reply keyboard) directly trigger the application review process.

Changes:
- Added a `MessageHandler` to the bot's dispatcher.
- This handler filters for text messages that exactly match "Review New Applications".
- When this text is received (i.e., the button is tapped), the handler calls the existing `review_applications_command`.
- This allows you to trigger the review of all new applications by simply tapping the button, in addition to using the `/review_applications` command.