### PR TITLE
Refactor: Update CV filename scheme and HR bot UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS, cross_origin # Make sure cross_origin is imported
 import os
 import asyncio # Added asyncio
-import uuid # Import uuid module
+# import uuid # Import uuid module - no longer needed
 import json # Import json module
 from datetime import datetime # Import datetime
 from dotenv import load_dotenv
@@ -157,8 +157,9 @@ def submit_application(): # Synchronous route
 
         if cv_file and allowed_file(cv_file.filename):
             original_filename = secure_filename(cv_file.filename)
-            # Generate a unique filename
-            unique_filename = f"{uuid.uuid4()}-{original_filename}"
+            # New timestamp-based unique filename:
+            timestamp_ms = int(datetime.utcnow().timestamp() * 1000)
+            unique_filename = f"{timestamp_ms}-{original_filename}"
             filename = unique_filename
 
             # Ensure uploads folder exists (Flask often runs from project root in dev)

--- a/hr_bot.py
+++ b/hr_bot.py
@@ -59,7 +59,7 @@ main_menu_keyboard = ReplyKeyboardMarkup(
 )
 
 review_mode_keyboard_layout = [
-    ["Next Page", "Previous Page"],
+    ["Previous Page", "Next Page"], # Swapped order
     ["Back to Main Menu"]
 ]
 review_mode_keyboard = ReplyKeyboardMarkup(
@@ -275,7 +275,13 @@ async def display_application_page(update: Update, context: ContextTypes.DEFAULT
         escaped_full_name = escape_markdown_v2(app_data.get('full_name', 'N/A'))
         escaped_email = escape_markdown_v2(app_data.get('email', 'N/A'))
         escaped_job_title = escape_markdown_v2(str(app_data.get('job_title', 'N/A')))
-        escaped_cv_filename_display = escape_markdown_v2(cv_filename)
+
+        # cv_filename is the full unique name from app_data.get('cv_filename', 'N/A')
+        # For display, we want the original name part.
+        parts = cv_filename.split('-', 1) # cv_filename here is cv_filename_stored
+        original_cv_name_for_display = parts[1] if len(parts) > 1 else cv_filename
+        escaped_original_cv_name_display = escape_markdown_v2(original_cv_name_for_display)
+
         submission_timestamp = escape_markdown_v2(str(app_data.get('timestamp', 'N/A')))
 
         # Process cover letter
@@ -299,7 +305,7 @@ async def display_application_page(update: Update, context: ContextTypes.DEFAULT
             message_text += f"*Cover Letter Snippet:*\n{escaped_cover_letter_snippet}\n\n"
 
         message_text += (
-            f"*CV Filename:* {escaped_cv_filename_display}\n" # Markdown fix: No backticks here
+            f"*Original CV Name:* {escaped_original_cv_name_display}\n"
             f"*Submitted:* {submission_timestamp}\n"
         )
 


### PR DESCRIPTION
This commit implements changes to the CV filename storage and display, and adjusts the HR bot's pagination button order based on your feedback.

**`app.py`:**
- I changed the CV filename storage scheme from UUID-based to `timestamp_in_milliseconds-originalfilename.ext`. This provides uniqueness while being more human-scannable in the filesystem. (e.g., `1678886400123-resume.pdf`).

**`hr_bot.py`:**
- **CV Filename Display:** In the `display_application_page` function, the bot now extracts and displays the `originalfilename.ext` part of the CV filename to the HR user (e.g., shows "Original CV Name: resume.pdf"). The full unique stored name is still used internally for button callbacks.
- **Button Order:** The "Next Page" and "Previous Page" buttons in the `review_mode_keyboard_layout` have had their order swapped to "Previous Page", "Next Page" for conventional UI flow.

**Frontend Refresh Investigation:**
- My analysis of the provided frontend HTML/JS files (e.g., `careers/virtual-assistant.html`) indicates that the JavaScript form submission logic uses `event.preventDefault()` and `fetch` correctly. This means the frontend code itself is unlikely to be the cause of a page refresh when actions (Accept/Reject) are taken in the separate Telegram bot.
- The observed page refresh is most likely due to a local web development server's file-watching feature auto-reloading the browser when `submitted_applications.log.json` is updated by the HR bot. This behavior is typical of dev environments and would not occur in a production deployment of static frontend files. You should check your dev server configuration if you wish to modify this auto-reload behavior.