### PR TITLE
fix: Serve Index.html and static assets from Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each component needs to be run in a separate terminal:
     ```bash
     python app.py
     ```
-    This will typically start the server on `http://127.0.0.1:5000/`.
+    This will typically start the server on `http://127.0.0.1:5000/`. You can access the main page (`Index.html`) by navigating to this root URL in your browser.
 
 2.  **HR Telegram Bot (`hr_bot.py`):**
     ```bash

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory, abort
 from flask_cors import CORS, cross_origin # Make sure cross_origin is imported
 import os
 import asyncio # Added asyncio
@@ -119,8 +119,18 @@ def load_blog_posts():
 
 # --- Routes ---
 @app.route('/')
-def hello_world():
-    return 'Hello, Bridgee Solutions Backend!'
+@cross_origin() # Add if CORS is applied globally, for consistency
+def serve_index():
+    return send_from_directory('.', 'Index.html')
+
+@app.route('/<path:filename>')
+@cross_origin() # For consistency
+def serve_static_files(filename):
+    # Basic security: prevent access to .py files or other sensitive files
+    # This is a simple check; more robust validation might be needed for production.
+    if filename.endswith('.py') or filename == '.env' or '.git' in filename:
+        return abort(404)
+    return send_from_directory('.', filename)
 
 @app.route('/api/blog-posts', methods=['GET'])
 @cross_origin()


### PR DESCRIPTION
This change modifies the Flask application (`app.py`) to serve the `Index.html` file from its root path (`/`). It also adds a route to serve other static files (e.g., images, CSS) referenced with relative paths from `Index.html`.

This resolves issues where `Index.html`, when opened directly as a file or from a simple local server, could not correctly fetch API data (due to same-origin policy) or load external resources (due to CORS issues with some CDNs when accessed from `file://` origin).

Changes include:
- Added a route in `app.py` for `/` to serve `Index.html`.
- Added a route in `app.py` for `/<path:filename>` to serve other static files from the project root, with a basic security check.
- Updated `README.md` to clarify that `Index.html` is accessible at the Flask server's root URL.