### PR TITLE
fix: Correct TypeError in Defaults and set polling timeouts

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -16,8 +16,7 @@ from telegram.ext import (
     ConversationHandler,
     MessageHandler,
     filters,
-    PicklePersistence, # Optional: for persisting bot data across restarts
-    Defaults
+    PicklePersistence # Optional: for persisting bot data across restarts
 )
 import asyncio
 
@@ -494,8 +493,7 @@ async def main() -> None:
     # persistence = PicklePersistence(filepath='./blog_bot_persistence')
     # application = ApplicationBuilder().token(BLOG_BOT_TOKEN).persistence(persistence).build()
 
-    defaults = Defaults(connect_timeout=20, read_timeout=20, pool_timeout=20)
-    application = ApplicationBuilder().token(BLOG_BOT_TOKEN).defaults(defaults).build()
+    application = ApplicationBuilder().token(BLOG_BOT_TOKEN).connect_timeout(20).read_timeout(20).build()
 
     logger.info("Attempting to initialize application for get_me()...")
     await application.initialize() # Explicitly initialize before direct bot calls


### PR DESCRIPTION
This commit resolves a TypeError in `blog_bot.py` caused by incorrect arguments passed to the `Defaults` constructor. The `Defaults` instantiation with timeout arguments has been removed.

Polling-specific timeouts (`connect_timeout` and `read_timeout`) have been set directly in the `ApplicationBuilder` to 20 seconds to potentially improve robustness for `get_updates` calls. The unused `Defaults` import was also removed.