### PR TITLE
fix: Revert blog_bot.py startup to simpler synchronous main

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -18,7 +18,7 @@ from telegram.ext import (
     filters,
     PicklePersistence # Optional: for persisting bot data across restarts
 )
-import asyncio
+# import asyncio # No longer explicitly needed here as run_polling manages its own loop
 
 # Load environment variables from .env file
 load_dotenv()
@@ -479,7 +479,7 @@ async def cancel_editing(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     return ConversationHandler.END
 
 # --- Main Bot Setup (main() function) ---
-async def main() -> None:
+def main() -> None:
     if not BLOG_BOT_TOKEN:
         logger.error("FATAL: BLOG_BOT_TOKEN not found in environment variables.")
         return
@@ -495,17 +495,8 @@ async def main() -> None:
 
     application = ApplicationBuilder().token(BLOG_BOT_TOKEN).connect_timeout(20).read_timeout(20).build()
 
-    logger.info("Attempting to initialize application for get_me()...")
-    await application.initialize() # Explicitly initialize before direct bot calls
-
-    try:
-        logger.info("Attempting to call get_me()...")
-        bot_info = await application.bot.get_me()
-        logger.info(f"Bot info received: {bot_info.username} (ID: {bot_info.id})")
-    except Exception as e:
-        logger.error(f"Error during get_me(): {e}", exc_info=True)
-        # Decide if to return or continue to run_polling
-        # For diagnostics, we'll let it try to run_polling anyway for now.
+    # Startup diagnostics (initialize and get_me calls) removed for simplification.
+    # run_polling() handles application initialization and bot connection.
 
     # Conversation handler for /newpost
     newpost_conv_handler = ConversationHandler(
@@ -554,4 +545,4 @@ async def main() -> None:
     logger.info("Blog Bot has stopped.")
 
 if __name__ == '__main__':
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
This commit reverts changes made to the `main()` function in `blog_bot.py` for diagnostic purposes. The goal is to restore the startup sequence to a simpler state that was previously working, to address `TimedOut` errors that appeared after `main` was made asynchronous with explicit `initialize` and `get_me` calls.

Changes include:
- Changed `async def main()` back to `def main()`.
- Removed explicit `await application.initialize()` and `await application.bot.get_me()` calls from `main()`.
- Changed the main execution call from `asyncio.run(main())` back to `main()`.
- Commented out the `import asyncio` line as it's no longer directly used by the script.
- Kept the `connect_timeout` and `read_timeout` settings in the `ApplicationBuilder` as they are correctly configured.