### PR TITLE
Fix: Correctly escape all literal parentheses in blog bot help text

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -210,13 +210,13 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
     help_text = (
         "I'm here to help you manage your website's blog posts\\! "
-        "Use the main menu buttons (shown with /start) to perform actions.\n\n"
+        "Use the main menu buttons \\(shown with /start\\) to perform actions.\n\n"
         "Here's how to use the main menu options:\n\n"
         "🔹 *Main Menu Navigation:*\n"
         "   - Use the buttons on the main menu to start an action.\n"
-        "   - In paginated lists (like when choosing a post or viewing all posts), use '⬅️ Previous' and '➡️ Next' buttons to navigate, and '🏠 Main Menu' to return.\n\n"
+        "   - In paginated lists \\(like when choosing a post or viewing all posts\\), use '⬅️ Previous' and '➡️ Next' buttons to navigate, and '🏠 Main Menu' to return.\n\n"
         "🔹 *Menu Options:*\n"
-        "   - *➕ Add New Post*: Starts the process to create a new blog post. I'll ask you for the title, content, author (optional), and an image URL (optional).\n\n"
+        "   - *➕ Add New Post*: Starts the process to create a new blog post. I'll ask you for the title, content, author \\(optional\\), and an image URL \\(optional\\).\n\n"
         "   - *📄 List All Posts*: Shows a paginated view of all your blog posts with their titles and publication dates for quick reference.\n\n"
         "   - *✏️ Edit a Post*: Allows you to modify an existing blog post.\n"
         "     1. I'll show you a paginated list of your posts.\n"
@@ -227,7 +227,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "     2. Press '\\[Select\\]' next to the post you want to delete.\n"
         "     3. You'll be asked to confirm the deletion before the post is permanently removed.\n\n"
         "🔹 *Cancelling an Operation:*\n"
-        "   - If you start an operation (like adding or editing a post) and want to stop, type /cancel. This will take you back to the main menu.\n\n"
+        "   - If you start an operation \\(like adding or editing a post\\) and want to stop, type /cancel. This will take you back to the main menu.\n\n"
         "Type /start at any time to see the main menu."
     )
     # Make sure to use MarkdownV2 for parsing this help text


### PR DESCRIPTION
This commit resolves the `telegram.error.BadRequest: Can't parse entities: character '(' is reserved...` error in the blog bot's /help command.

Previously missed instances of literal parentheses `()` in the `help_text` string were not escaped for MarkdownV2. This commit ensures that all such parentheses, along with other previously addressed special characters (`!`, `[`, `]`, relevant `.`), are now correctly escaped using a preceding backslash (e.g., `\(` and `\)`).

The `help_text` should now be fully compatible with Telegram's MarkdownV2 parsing, allowing the help message to be sent and displayed correctly.