### PR TITLE
Fix: Switch blog bot help text to HTML parse mode

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -209,33 +209,33 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if not await is_admin(update, context):
         return
     help_text = (
-        "I'm here to help you manage your website's blog posts\\! "
-        "Use the main menu buttons \\(shown with /start\\) to perform actions.\n\n"
+        "I'm here to help you manage your website's blog posts! "
+        "Use the main menu buttons (shown with /start) to perform actions.\n\n"
         "Here's how to use the main menu options:\n\n"
-        "🔹 *Main Menu Navigation:*\n"
+        "🔹 <b>Main Menu Navigation:</b>\n"
         "   - Use the buttons on the main menu to start an action.\n"
-        "   - In paginated lists \\(like when choosing a post or viewing all posts\\), use '⬅️ Previous' and '➡️ Next' buttons to navigate, and '🏠 Main Menu' to return.\n\n"
-        "🔹 *Menu Options:*\n"
-        "   - *➕ Add New Post*: Starts the process to create a new blog post. I'll ask you for the title, content, author \\(optional\\), and an image URL \\(optional\\).\n\n"
-        "   - *📄 List All Posts*: Shows a paginated view of all your blog posts with their titles and publication dates for quick reference.\n\n"
-        "   - *✏️ Edit a Post*: Allows you to modify an existing blog post.\n"
+        "   - In paginated lists (like when choosing a post or viewing all posts), use '⬅️ Previous' and '➡️ Next' buttons to navigate, and '🏠 Main Menu' to return.\n\n"
+        "🔹 <b>Menu Options:</b>\n"
+        "   - <b>➕ Add New Post</b>: Starts the process to create a new blog post. I'll ask you for the title, content, author (optional), and an image URL (optional).\n\n"
+        "   - <b>📄 List All Posts</b>: Shows a paginated view of all your blog posts with their titles and publication dates for quick reference.\n\n"
+        "   - <b>✏️ Edit a Post</b>: Allows you to modify an existing blog post.\n"
         "     1. I'll show you a paginated list of your posts.\n"
-        "     2. Press '\\[Select\\]' next to the post you want to edit.\n"
-        "     3. Confirm your choice, then select which part of the post \\(title, content, etc\\.\\) you want to change using the buttons provided.\n\n"
-        "   - *🗑️ Delete a Post*: Lets you remove a blog post.\n"
+        "     2. Press '[Select]' next to the post you want to edit.\n"
+        "     3. Confirm your choice, then select which part of the post (title, content, etc.) you want to change using the buttons provided.\n\n"
+        "   - <b>🗑️ Delete a Post</b>: Lets you remove a blog post.\n"
         "     1. I'll show you a paginated list of your posts.\n"
-        "     2. Press '\\[Select\\]' next to the post you want to delete.\n"
+        "     2. Press '[Select]' next to the post you want to delete.\n"
         "     3. You'll be asked to confirm the deletion before the post is permanently removed.\n\n"
-        "🔹 *Cancelling an Operation:*\n"
-        "   - If you start an operation \\(like adding or editing a post\\) and want to stop, type /cancel. This will take you back to the main menu.\n\n"
+        "🔹 <b>Cancelling an Operation:</b>\n"
+        "   - If you start an operation (like adding or editing a post) and want to stop, type /cancel. This will take you back to the main menu.\n\n"
         "Type /start at any time to see the main menu."
     )
-    # Make sure to use MarkdownV2 for parsing this help text
+    # Make sure to use HTML for parsing this help text
     effective_message = update.effective_message
     if update.callback_query: # If called from menu_help callback
         effective_message = update.callback_query.message
 
-    await effective_message.reply_text(help_text, parse_mode='MarkdownV2')
+    await effective_message.reply_text(help_text, parse_mode='HTML')
 
 # --- Other Command Handlers ---
 async def listposts_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
Resolves persistent `telegram.error.BadRequest` errors caused by MarkdownV2 entity parsing in the /help command.

The `help_text` string has been converted from MarkdownV2 to HTML format (e.g., using <b> tags for bolding). The `parse_mode` in the `help_command` function when sending the help message has been changed from `MarkdownV2` to `HTML`.

This change leverages HTML's more lenient parsing for literal characters like '!', '.', '(', ')', '[', ']', which were causing issues with MarkdownV2's strict escaping requirements. The help message should now be reliably sent and displayed correctly.