### PR TITLE
Fix: Correct async initialization for blog_bot.py

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -18,7 +18,7 @@ from telegram.ext import (
     filters,
     PicklePersistence
 )
-# import asyncio # No longer explicitly needed here as run_polling manages its own loop
+import asyncio # Ensure asyncio is imported
 
 # Load environment variables from .env file
 load_dotenv()
@@ -1052,7 +1052,7 @@ async def handle_show_main_menu_callback(update: Update, context: ContextTypes.D
     await start_command(update, context)
 
 # --- Main Bot Setup (main() function) ---
-def main() -> None:
+async def main() -> None: # Changed to async def
     if not BLOG_BOT_TOKEN:
         logger.error("FATAL: BLOG_BOT_TOKEN not found in environment variables.")
         return
@@ -1060,6 +1060,7 @@ def main() -> None:
         logger.warning("WARNING: BLOG_ADMIN_CHAT_ID not found. Bot will be usable by anyone.")
 
     application = ApplicationBuilder().token(BLOG_BOT_TOKEN).connect_timeout(20).read_timeout(20).build()
+    await application.initialize() # Added initialize
 
     newpost_conv_handler = ConversationHandler(
         entry_points=[
@@ -1129,8 +1130,8 @@ def main() -> None:
     application.add_handler(CommandHandler("cancel", cancel_newpost))
 
     logger.info("Blog Bot starting...")
-    application.run_polling()
+    application.run_polling() # run_polling itself is not awaited
     logger.info("Blog Bot has stopped.")
 
 if __name__ == '__main__':
-    main()
+    asyncio.run(main()) # Changed to asyncio.run


### PR DESCRIPTION
Resolves a `RuntimeError: ExtBot is not properly initialized` that occurred during bot startup.

The `main()` function has been refactored to be an `async def main()`. Inside `main()`, `await application.initialize()` is now explicitly called before `application.run_polling()` to ensure the `ExtBot` and other asynchronous components are fully initialized. The script's entry point has been updated to use `asyncio.run(main())`. `import asyncio` has been added.

These changes align with `python-telegram-bot` v20+ asynchronous best practices and ensure the bot application is properly initialized within an asyncio event loop before polling begins.