### PR TITLE
Fix: Re-apply correct asyncio startup sequence for blog bot

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -1067,7 +1067,7 @@ async def main() -> None: # Changed to async def
         .read_timeout(30)     # Set read timeout to 30 seconds
         .build()
     )
-    await application.initialize() # Added initialize
+    await application.initialize()
 
     newpost_conv_handler = ConversationHandler(
         entry_points=[
@@ -1137,7 +1137,9 @@ async def main() -> None: # Changed to async def
     application.add_handler(CommandHandler("cancel", cancel_newpost))
 
     logger.info("Blog Bot starting...")
-    application.run_polling() # run_polling itself is not awaited
+    await application.start()
+    await application.updater.start_polling()
+    await application.idle()
     logger.info("Blog Bot has stopped.")
 
 if __name__ == '__main__':


### PR DESCRIPTION
Re-applies the fix to resolve the `RuntimeError: This event loop is already running`. The `async def main()` function in `blog_bot.py` was definitively updated to replace the blocking `application.run_polling()` call with the non-blocking sequence:
- `await application.start()`
- `await application.updater.start_polling()`
- `await application.idle()`

This ensures that the `python-telegram-bot` library's components operate harmoniously within the event loop managed by `asyncio.run()`, preventing conflicts and allowing the bot to start and run correctly.