### PR TITLE
Fix: Correct AttributeError for idle() call in blog bot startup

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -1139,7 +1139,7 @@ async def main() -> None: # Changed to async def
     logger.info("Blog Bot starting...")
     await application.start()
     await application.updater.start_polling()
-    await application.idle()
+    await application.updater.idle() # Changed from application.idle()
     logger.info("Blog Bot has stopped.")
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves the `AttributeError: 'Application' object has no attribute 'idle'`.

The method to keep the bot running indefinitely after starting polling was incorrectly called on the `Application` object. This commit changes the call from `await application.idle()` to `await application.updater.idle()`, which is the correct usage in `python-telegram-bot` v20+ for this purpose.

This allows the bot to start, initialize, begin polling, and then idle correctly, waiting for updates or termination signals.