### PR TITLE
Fix: Specify UTF-8 encoding when reading blog_posts.json in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,7 +100,7 @@ def load_blog_posts():
         print(f"INFO: {BLOG_POSTS_FILE} not found. Returning empty list.")
         return []
     try:
-        with open(BLOG_POSTS_FILE, 'r') as f:
+        with open(BLOG_POSTS_FILE, 'r', encoding='utf-8') as f:
             content = f.read()
             if not content:
                 print(f"INFO: {BLOG_POSTS_FILE} is empty. Returning empty list.")


### PR DESCRIPTION
Resolves a `UnicodeDecodeError` that led to a 500 Internal Server Error on your `/api/blog-posts` route.

The `load_blog_posts` function in `app.py` was attempting to read `blog_posts.json` using the system's default encoding. This caused an error if the file (written in UTF-8 by `blog_bot.py`) contained characters not representable in the default encoding (e.g., cp1252).

The fix modifies the `open()` call in `load_blog_posts` to explicitly use `encoding='utf-8'`, ensuring consistency with how the file is written and preventing decoding errors.