### PR TITLE
Fix: Update document filter for Markdown files

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -899,7 +899,7 @@ async def main() -> None:
             ],
             RECEIVE_TYPED_CONTENT: [MessageHandler(filters.TEXT & ~filters.COMMAND, receive_typed_content_message)],
             RECEIVE_CONTENT_FILE: [
-                MessageHandler(filters.Document.TEXT | filters.Document.MARKDOWN, receive_content_file_upload),
+                MessageHandler(filters.Document.TEXT | filters.Document.FileExtension('md'), receive_content_file_upload),
                 MessageHandler(filters.TEXT & ~filters.COMMAND, handle_unexpected_message_in_file_state)
             ],
             AUTHOR: [MessageHandler(filters.TEXT & ~filters.COMMAND, receive_author)],


### PR DESCRIPTION
Replaced `filters.Document.MARKDOWN` with `filters.Document.FileExtension('md')` in the `newpost_conv_handler` for `blog_bot.py`.

This change addresses an `AttributeError` caused by API changes in `python-telegram-bot` v20.0+, where `filters.Document.MARKDOWN` is no longer a valid attribute. The new filter correctly identifies Markdown files by their '.md' file extension.