### PR TITLE
Revert: Correct handler assignment in editpost_conv_handler

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -548,7 +548,7 @@ async def prompt_action_for_selected_post(update: Update, context: ContextTypes.
     message_text = (
         f"You selected: *{escaped_post_title}*\n"
         f"ID: `{escaped_post_id_for_display}`\n\n"
-        f"What would you like to do with this post\?"
+        f"What would you like to do with this post?"
     )
 
     keyboard = [
@@ -914,7 +914,7 @@ async def main() -> None:
             CallbackQueryHandler(handle_do_edit_post_init_callback, pattern='^do_edit_post_init:')
         ],
         states={
-            SELECT_FIELD_TO_EDIT: [CallbackQueryHandler(handle_post_selection_callback, pattern='^editfield_')],
+            SELECT_FIELD_TO_EDIT: [CallbackQueryHandler(handle_field_selection_callback, pattern='^editfield_')],
             GET_NEW_FIELD_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, receive_new_field_value)],
         },
         fallbacks=[


### PR DESCRIPTION
Reverted the handler for the SELECT_FIELD_TO_EDIT state in the editpost_conv_handler from `handle_post_selection_callback` back to `handle_field_selection_callback`.

This restores the original intended reference, acknowledging that `handle_field_selection_callback` is an undefined function. The previous change was an incorrect attempt to fix a NameError by pointing to an existing but unsuitable function. This commit more accurately reflects the incomplete state of the edit post feature.