### PR TITLE
I've addressed a `SyntaxWarning` and enhanced the logging for Markdow…

### DIFF
--- a/blog_bot.py
+++ b/blog_bot.py
@@ -134,8 +134,10 @@ async def receive_title(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
 async def handle_content_type_direct_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
     await query.answer()
+    text_to_send = "Okay, please send the full content of the blog post as a text message\\. Remember Telegram has a character limit for messages\\. \\(Or type /cancel\\)"
+    logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{text_to_send}<<<")
     await query.edit_message_text(
-        text="Okay, please send the full content of the blog post as a text message\\. Remember Telegram has a character limit for messages\\. \\(Or type /cancel\\)",
+        text=text_to_send,
         parse_mode='MarkdownV2'
     )
     return RECEIVE_TYPED_CONTENT
@@ -143,8 +145,10 @@ async def handle_content_type_direct_callback(update: Update, context: ContextTy
 async def handle_content_type_file_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
     await query.answer()
+    text_to_send = "Please upload a plain text file \\(\\.txt\\) or a Markdown file \\(\\.md\\) containing the blog content\\. Max file size: 1MB, UTF\\-8 encoded\\. \\(Or type /cancel\\)"
+    logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{text_to_send}<<<")
     await query.edit_message_text(
-        text="Please upload a plain text file \\(\\.txt\\) or a Markdown file \\(\\.md\\) containing the blog content\\. Max file size: 1MB, UTF\\-8 encoded\\. \\(Or type /cancel\\)",
+        text=text_to_send,
         parse_mode='MarkdownV2'
     )
     return RECEIVE_CONTENT_FILE
@@ -414,8 +418,10 @@ async def display_post_selection_page(update: Update, context: ContextTypes.DEFA
         all_posts = load_blog_posts()
         if not all_posts:
             keyboard = [[InlineKeyboardButton("🏠 Main Menu", callback_data='show_main_menu')]]
+            text_to_send = f"There are no posts to {escape_markdown_v2(str(action))}. Would you like to create one?"
+            logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{text_to_send}<<<")
             await query.edit_message_text(
-                text=f"There are no posts to {escape_markdown_v2(str(action))}. Would you like to create one?",
+                text=text_to_send,
                 reply_markup=InlineKeyboardMarkup(keyboard), parse_mode='MarkdownV2'
             )
             return
@@ -428,8 +434,10 @@ async def display_post_selection_page(update: Update, context: ContextTypes.DEFA
     cached_posts = context.user_data.get('paginated_posts_cache', [])
     if not cached_posts:
         keyboard = [[InlineKeyboardButton("🏠 Main Menu", callback_data='show_main_menu')]]
+        text_to_send = f"There are no posts to {escape_markdown_v2(str(action))}. Would you like to create one?"
+        logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{text_to_send}<<<")
         await query.edit_message_text(
-            text=f"There are no posts to {escape_markdown_v2(str(action))}. Would you like to create one?",
+            text=text_to_send,
             reply_markup=InlineKeyboardMarkup(keyboard), parse_mode='MarkdownV2'
         )
         return
@@ -478,7 +486,7 @@ async def display_post_selection_page(update: Update, context: ContextTypes.DEFA
 
     reply_markup = InlineKeyboardMarkup(keyboard_buttons)
     try:
-        logger.info(f"MarkdownV2 message content before sending: >>>{message_text}<<<")
+        logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{message_text}<<<")
         await query.edit_message_text(text=message_text, reply_markup=reply_markup, parse_mode='MarkdownV2')
     except Exception as e:
         logger.error(f"Error sending paginated message (MarkdownV2 failed, trying plain): {e}")
@@ -725,6 +733,7 @@ async def display_readonly_posts_page(update: Update, context: ContextTypes.DEFA
 
     reply_markup = InlineKeyboardMarkup(keyboard_buttons)
     try:
+        logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{message_text}<<<")
         await query.edit_message_text(text=message_text, reply_markup=reply_markup, parse_mode='MarkdownV2')
     except Exception as e:
         logger.error(f"MarkdownV2 failed in display_readonly_posts_page: {e}. Sending plain.")
@@ -823,6 +832,7 @@ async def prompt_select_field_to_edit(update: Update, context: ContextTypes.DEFA
     ]
     reply_markup = InlineKeyboardMarkup(keyboard)
 
+    logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{message_text}<<<")
     await query.edit_message_text(text=message_text, reply_markup=reply_markup, parse_mode='MarkdownV2')
     return SELECT_FIELD_TO_EDIT
 
@@ -880,8 +890,9 @@ async def handle_field_selection_callback(update: Update, context: ContextTypes.
     message_text = (
         f"You chose to edit: *{escape_markdown_v2(user_friendly_field_name)}*\\.\n\n"
         f"Please send the new {escape_markdown_v2(user_friendly_field_name)} for the post\\. "
-        f"\(Or type /cancel_editing to abort this edit\)"
+        f"\\(Or type /cancel_editing to abort this edit\\)"
     )
+    logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{message_text}<<<")
     await query.edit_message_text(text=message_text, parse_mode='MarkdownV2')
     return GET_NEW_FIELD_VALUE
 
@@ -987,6 +998,7 @@ async def handle_do_delete_post_prompt_callback(update: Update, context: Context
         InlineKeyboardButton("No, Cancel", callback_data="show_main_menu")
     ]]
     reply_markup = InlineKeyboardMarkup(keyboard)
+    logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{message_text}<<<")
     await query.edit_message_text(text=message_text, reply_markup=reply_markup, parse_mode='MarkdownV2')
 
 async def handle_do_delete_post_confirm_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -1037,6 +1049,7 @@ async def handle_do_delete_post_confirm_callback(update: Update, context: Contex
     context.user_data.pop('current_page_num', None)
     context.user_data.pop('current_action_type', None)
 
+    logger.info(f"Attempting to edit message with MarkdownV2. Text: >>>{message_to_user}<<<")
     await query.edit_message_text(text=message_to_user, parse_mode='MarkdownV2')
     await start_command(update, context)
 


### PR DESCRIPTION
…nV2 messages.

Specifically, I:
- Corrected a `SyntaxWarning` in the `handle_field_selection_callback` function related to parentheses within an f-string.
- Implemented INFO-level logging for the `text` argument in all instances where `.edit_message_text()` is called with `parse_mode='MarkdownV2'`. This will help capture the precise message content being sent, which should aid in diagnosing ongoing `BadRequest` errors associated with Markdown parsing.