### PR TITLE
Feat: Implement individual blog post pages

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1069,7 +1069,7 @@
                         <h3 class="text-xl font-bold text-gray-800 mb-3">${post.title || 'Untitled Post'}</h3>
                         <p class="text-sm text-gray-500 mb-2">By ${author} on ${datePublished}</p>
                         <p class="text-base text-gray-600 mb-4 leading-relaxed flex-grow">${contentSnippet}</p>
-                        <a href="blog-post.html?id=${post.id || ''}" class="text-blue-600 font-medium inline-flex items-center self-start focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Read More <i class="fas fa-arrow-right ml-2"></i></a>
+                        <a href="/post/${post.id}" class="text-blue-600 font-medium inline-flex items-center self-start focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md">Read More <i class="fas fa-arrow-right ml-2"></i></a>
                     `;
                     blogPostsContainer.appendChild(postElement);
                 });

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify, send_from_directory, abort
+from flask import Flask, request, jsonify, send_from_directory, abort, render_template
 from flask_cors import CORS, cross_origin # Make sure cross_origin is imported
 import os
 import asyncio # Added asyncio
@@ -147,6 +147,16 @@ def get_blog_post(post_id):
         return jsonify(post), 200
     else:
         return jsonify({'error': 'Post not found'}), 404
+
+@app.route('/post/<string:post_id>')
+@cross_origin()
+def view_post(post_id):
+    posts = load_blog_posts()
+    found_post = next((p for p in posts if p.get('id') == post_id), None)
+    if found_post:
+        return render_template('post.html', post=found_post)
+    else:
+        abort(404)
 
 @app.route('/api/submit-application', methods=['POST', 'OPTIONS'])
 @cross_origin() # Keep CORS decorator

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ post.title | escape }} - My Blog</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <style>
+        /* Basic inline styles for readability if no external CSS is present */
+        body { font-family: sans-serif; line-height: 1.6; margin: 20px; color: #333; background-color: #f4f4f4; }
+        header, footer { text-align: center; margin-bottom: 20px; padding: 10px 0; }
+        header { border-bottom: 1px solid #ddd; }
+        footer { border-top: 1px solid #ddd; margin-top: 40px; font-size: 0.9em; color: #555; }
+        main { max-width: 800px; margin: 0 auto; background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        h1 { color: #333; }
+        img.post-image { max-width: 100%; height: auto; margin-bottom: 20px; border-radius: 4px; }
+        .post-meta { font-size: 0.9em; color: #555; margin-bottom: 20px; }
+        .post-meta .author { font-weight: bold; }
+        .post-meta .date { margin-left: 5px; }
+        .post-content { margin-top: 20px; }
+        .back-link { display: inline-block; margin-bottom: 20px; color: #007bff; text-decoration: none; }
+        .back-link:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <header>
+        <a href="{{ url_for('serve_index') }}" class="back-link">&larr; Back to Blog List</a>
+    </header>
+    <main>
+        <h1>{{ post.title | escape }}</h1>
+        <p class="post-meta">
+            {% if post.author %}
+                By: <span class="author">{{ post.author | escape }}</span>
+            {% else %}
+                By: <span class="author">Anonymous</span>
+            {% endif %}
+            {% if post.date_published %}
+                <span class="date"> | Published on: {{ post.date_published | escape }}</span> {# Consider date formatting filter if available #}
+            {% endif %}
+        </p>
+        {% if post.image_url %}
+            {# Check if image_url is an external URL or needs url_for #}
+            {% if post.image_url.startswith('http') or post.image_url.startswith('/') %}
+                <img src="{{ post.image_url }}" alt="{{ post.title | escape }}" class="post-image">
+            {% else %}
+                <img src="{{ url_for('static', filename=post.image_url) }}" alt="{{ post.title | escape }}" class="post-image">
+            {% endif %}
+        {% endif %}
+        <div class="post-content">
+            {# ** CRITICAL: Ensure post.content is SANITIZED before being passed to this template #}
+            {# or use a custom Jinja filter that sanitizes. Using |safe assumes pre-sanitized HTML. #}
+            {# If content_is_html flag is true, use |safe, otherwise escape #}
+            {% if post.content_is_html %}
+                {{ post.content | safe }}
+            {% else %}
+                {{ post.content | escape | nl2br }} {# nl2br might be useful if it's plain text #}
+            {% endif %}
+        </div>
+    </main>
+    <footer>
+        <p>&copy; 2024 My Blog</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
This feature allows you to view individual blog posts on dedicated pages, accessible via "Read more" links from the main blog listing on Index.html.

Key changes:
- `app.py`:
    - Added a new Flask route `/post/<post_id>` with a `view_post(post_id)` function. This function loads blog data, finds the specified post, and renders a new `post.html` template or returns a 404 if not found.
    - Confirmed use of existing `load_blog_posts()` helper function.
- `templates/post.html`:
    - Created a new HTML template to display a single blog post.
    - Shows title, author, publication date, and image (if available).
    - Renders `post.content` using `{{ post.content | safe }}` if the `content_is_html` flag is true (for .docx uploads), otherwise uses `{{ post.content | escape | nl2br }}` for plain text.
    - Includes a "Back to Blog List" link and basic styling.
- `Index.html`:
    - Updated the JavaScript that dynamically loads blog posts to change the "Read more" links to point to the new `/post/<post_id>` route.

**Security Reminder for you:**
The `post.html` template uses `|safe` to render HTML content from Word documents. It is CRITICAL to sanitize this HTML content (e.g., using the `bleach` Python library) either in `blog_bot.py` after conversion by `mammoth` (before saving to JSON) or in `app.py` before passing it to `render_template`. This was not part of this commit but is essential for preventing XSS vulnerabilities.