### PR TITLE
refactor(hr_bot): Omit User ID from 'Last Action' display in Telegram

### DIFF
--- a/hr_bot.py
+++ b/hr_bot.py
@@ -286,8 +286,7 @@ async def _display_application_page_common(update: Update, context: ContextTypes
                 formatted_timestamp = escape_markdown_v2(reviewed_timestamp_raw)
 
             actor_info_display = escape_markdown_v2(reviewed_by_name_raw)
-            if reviewed_by_id_raw:
-                 actor_info_display += f" \\(ID: {escape_markdown_v2(str(reviewed_by_id_raw))}\\)" # Escaped parentheses
+            # Removed ID display: if reviewed_by_id_raw: actor_info_display += f" \\(ID: {escape_markdown_v2(str(reviewed_by_id_raw))}\\)"
             message_text += f"*Last Action:* {formatted_timestamp} by {actor_info_display}\n"
 
         keyboard_buttons = []
@@ -525,8 +524,7 @@ async def button_callback_handler(update: Update, context: ContextTypes.DEFAULT_
                     formatted_timestamp = escape_markdown_v2(reviewed_timestamp_raw_updated)
 
                 actor_info = escape_markdown_v2(reviewed_by_name_updated)
-                if reviewed_by_id_updated:
-                    actor_info += f" \\(ID: {escape_markdown_v2(str(reviewed_by_id_updated))}\\)" # Escaped parentheses
+                # Removed ID display: if reviewed_by_id_updated: actor_info += f" \\(ID: {escape_markdown_v2(str(reviewed_by_id_updated))}\\)"
                 message_text_updated += f"*Last Action:* {formatted_timestamp} by {actor_info}\n"
 
             keyboard_buttons_updated = []


### PR DESCRIPTION
This commit updates `hr_bot.py` to remove the Telegram User ID from the "Last Action" information displayed in messages to you. This change is for enhanced privacy/security, reducing the exposure of User IDs in the chat interface.

Key changes:
- Modified `_display_application_page_common` and the message update logic within `button_callback_handler`.
- The "Last Action" string displayed in Telegram messages (e.g., "*Last Action:* {timestamp} by {admin_name} (ID: {user_id})") has been changed to remove the "(ID: {user_id})" part.
- It now displays only the timestamp and the admin's name (e.g., "*Last Action:* {timestamp} by {admin_name}").
- The actual User ID (`reviewed_by` field) continues to be stored in the `submitted_applications.log.json` file for auditing and internal records but is no longer part of the message text shown in Telegram.
- MarkdownV2 escaping for the timestamp and admin name components is maintained.

This change enhances user privacy in the bot interface without losing the underlying data.