### PR TITLE
Okay, I've reverted the hero section fade effect height.

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -49,7 +49,7 @@
       bottom: 0;
       left: 0;
       width: 100%;
-      height: 200px; /* Changed from 100px */
+      height: 100px; /* Reverted to 100px */
       background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
       pointer-events: none; /* Ensure it doesn't interfere with mouse events */
     }


### PR DESCRIPTION
I modified the CSS for the `.hero-gradient::after` pseudo-element in `Index.html` to change its height from `200px` back to `100px`.

This adjustment makes the fade-to-white effect at the bottom of the hero section shorter, as you requested.