### PR TITLE
Fix services dropdown text visibility on transparent homepage navbar

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -111,6 +111,21 @@
       color: #d1d5db !important; /* Light gray for hover, matching other links */
     }
 
+    /* Styles for Services Dropdown in Transparent Navbar State */
+    #main-navbar.navbar-transparent .services-dropdown {
+      background-color: rgba(55, 65, 81, 0.92) !important; /* bg-gray-700 with 92% opacity for better text readability */
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.03) !important; /* Lighter shadow (Tailwind's shadow-md equivalent) */
+    }
+
+    #main-navbar.navbar-transparent .services-dropdown a {
+      color: #FFFFFF !important;
+    }
+
+    #main-navbar.navbar-transparent .services-dropdown a:hover {
+      background-color: rgba(31, 41, 55, 0.95) !important; /* bg-gray-800 with 95% opacity */
+      color: #d1d5db !important; /* text-gray-300 */
+    }
+
     /* --- Styles for the solid state (when scrolling) --- */
     /* These will be reapplied by removing .navbar-transparent and letting Tailwind classes take over, */
     /* but we need to ensure specificity or define a .navbar-solid if Tailwind is aggressively overridden. */
@@ -545,7 +560,7 @@
                         <button class="text-gray-700 hover:text-blue-600 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 focus:ring-offset-white rounded-md inline-flex items-center">
                             Services <i class="fas fa-chevron-down ml-2 text-xs"></i>
                         </button>
-                        <div class="absolute left-0 w-56 bg-white rounded-md shadow-lg py-1 pt-2 z-20 hidden group-hover:block group-focus-within:block">
+                        <div class="services-dropdown absolute left-0 w-56 bg-white rounded-md shadow-lg py-1 pt-2 z-20 hidden group-hover:block group-focus-within:block">
                             <a href="service-virtual-assistance.html" class="block px-4 py-2 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-600 rounded-md">Virtual Assistance</a>
                             <a href="service-software-development.html" class="block px-4 py-2 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-600 rounded-md">Software Development</a>
                             <a href="service-bpo.html" class="block px-4 py-2 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-600 rounded-md">Custom BPO Services</a>


### PR DESCRIPTION
- Added CSS to Index.html to style the services dropdown menu when the navbar is transparent.
- In the transparent state, the dropdown background is now semi-transparent dark gray, and link text is white for better visibility and consistency.
- Hover states for dropdown links in transparent mode are also updated.
- Ensured that styles correctly revert to default (white background, dark gray text) when the navbar becomes solid on scroll or on other pages.