### PR TITLE
Fix and rebalance technology logos on homepage

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -757,46 +757,50 @@
                         <span class="text-sm font-medium text-gray-700">Salesforce</span>
                     </div>
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <img src="https://i.imgur.com/eQ9hPF9.png" alt="Pipedrive" class="h-16 w-16 mb-2"> <!-- Placeholder/custom link -->
+                        <img src="https://cdn.svgporn.com/logos/pipedrive.svg" alt="Pipedrive" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Pipedrive</span>
                     </div>
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <img src="https://i.imgur.com/n9g8c9L.png" alt="Zoho CRM" class="h-16 w-16 mb-2"> <!-- Placeholder/custom link -->
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/zoho/zoho-original.svg" alt="Zoho CRM" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Zoho CRM</span>
                     </div>
                 </div>
                 <p class="text-lg text-gray-700 font-semibold mt-10 mb-6 text-center">Outreach</p>
                 <div class="tech-logo-row" id="tech-logo-row-outreach" style="margin-top: 20px;">
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <img src="https://i.imgur.com/VpLd47N.png" alt="LinkedIn Sales Navigator" class="h-16 w-16 mb-2"> <!-- Placeholder/custom link -->
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linkedin/linkedin-original.svg" alt="LinkedIn Sales Navigator" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">LinkedIn Sales Navigator</span>
                     </div>
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <img src="https://i.imgur.com/9k8Gj4Z.png" alt="Apollo.io" class="h-16 w-16 mb-2"> <!-- Placeholder/custom link -->
+                        <img src="https://www.vectorlogo.zone/logos/apolloio/apolloio-icon.svg" alt="Apollo.io" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Apollo.io</span>
                     </div>
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <img src="https://i.imgur.com/6yZzA9k.png" alt="Lemlist" class="h-16 w-16 mb-2"> <!-- Placeholder/custom link -->
+                        <img src="https://asset.brandfetch.io/id4F5mbo0L/id13U9iLrq.svg" alt="Lemlist" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Lemlist</span>
                     </div>
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <img src="https://i.imgur.com/j4xOR3W.png" alt="Mailshake" class="h-16 w-16 mb-2"> <!-- Placeholder/custom link -->
+                        <img src="https://asset.brandfetch.io/idobbS7jSp/idnmLGNLAL.svg" alt="Mailshake" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Mailshake</span>
                     </div>
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <img src="https://i.imgur.com/3YtB0rW.png" alt="Hunter.io" class="h-16 w-16 mb-2"> <!-- Placeholder/custom link -->
+                        <img src="https://asset.brandfetch.io/id1Y7bQdYx/id3jJ2JLzD.svg" alt="Hunter.io" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Hunter.io</span>
                     </div>
                 </div>
                 <p class="text-lg text-gray-700 font-semibold mt-10 mb-6 text-center">Scheduling</p>
                 <div class="tech-logo-row" id="tech-logo-row-scheduling" style="margin-top: 20px;">
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <img src="https://i.imgur.com/x0n9fp0.png" alt="Calendly" class="h-16 w-16 mb-2"> <!-- Placeholder/custom link -->
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/calendly/calendly-original.svg" alt="Calendly" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Calendly</span>
                     </div>
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/googlecalendar/googlecalendar-original.svg" alt="Google Calendar" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Google Calendar</span>
+                    </div>
+                    <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/notion/notion-original.svg" alt="Notion" class="h-16 w-16 mb-2">
+                        <span class="text-sm font-medium text-gray-700">Notion</span>
                     </div>
                 </div>
                 <p class="text-lg text-gray-700 font-semibold mt-10 mb-6 text-center">Reporting</p>
@@ -808,10 +812,6 @@
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/microsoftexcel/microsoftexcel-original.svg" alt="Excel" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Excel</span>
-                    </div>
-                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/notion/notion-original.svg" alt="Notion" class="h-16 w-16 mb-2">
-                        <span class="text-sm font-medium text-gray-700">Notion</span>
                     </div>
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/airtable/airtable-original.svg" alt="Airtable" class="h-16 w-16 mb-2">


### PR DESCRIPTION
- Replaced 8 placeholder/Imgur logo URLs in the 'Our Technology Stack' section of Index.html with reliable SVG CDN links (from Devicons, SVG Porn, Brandfetch, etc.).
- Moved the 'Notion' logo from the 'Reporting' category to 'Scheduling' to improve the numerical balance of logos across the rows.
- Ensured all 15 logos now use more stable sources, improving display reliability.