### PR TITLE
Refactor technology stack section to two rows and remove titles

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -746,76 +746,85 @@
             </div>
             
             <div class="tech-logo-scroller-container" style="overflow: hidden; padding: 20px 0;">
-                <p class="text-lg text-gray-700 font-semibold mb-6 text-center">CRM</p>
-                <div class="tech-logo-row" id="tech-logo-row-crm">
+                <div class="tech-logo-row" id="tech-logo-row-1" style="margin-bottom: 20px;">
+                    <!-- HubSpot -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>HubSpot</title><path d="M12.004 0C5.38 0 0 5.38 0 12.004s5.38 12.004 12.004 12.004 12.004-5.38 12.004-12.004S18.628 0 12.004 0zm5.434 16.206c.204.288.204.72 0 1.008l-.546.772c-.204.288-.57.383-.897.268a8.42 8.42 0 0 1-3.992-1.662 8.73 8.73 0 0 1-2.904-3.042c-.07-.16-.07-.34 0-.5l.002-.007a.61.61 0 0 1 .05-.142c.29-.705.54-1.42.746-2.14.16-.57.382-1.12.61-1.64a.66.66 0 0 1 .21-.27c.204-.144.48-.144.684 0l.438.308c.204.144.288.408.216.648a10.34 10.34 0 0 0-.432 2.083c-.03.28-.05.56-.06.84l-.004.1c.28.92.79 1.76 1.46 2.45a7.32 7.32 0 0 0 2.887 1.723zm-10.86-3.59a.63.63 0 0 1-.684-.01c-.204-.144-.48-.144-.684 0l-.438.308c-.204.144-.288.408-.216.648a10.35 10.35 0 0 0 .528 2.31c.03.1.05.2.08.3l.002.008a8.42 8.42 0 0 1-3.82-1.475.66.66 0 0 1-.204-.936l.546-.772c.204-.288.57-.383.897-.268a8.42 8.42 0 0 1 3.992 1.662 8.73 8.73 0 0 1 2.904 3.042c.08.16.08.34 0 .5l-.002.007a.61.61 0 0 1-.05.142c-.29.705-.54 1.42-.746 2.14-.16.57-.382 1.12-.61 1.64a.66.66 0 0 1-.21.27c-.204-.144-.48-.144-.684 0l-.438.308c-.204.144-.288.408-.216.648a10.34 10.34 0 0 0 .432 2.083zm7.39-8.06a.63.63 0 0 1-.684-.01c-.204-.144-.48-.144-.684 0l-.438.308c-.204.144-.288.408-.216.648a10.35 10.35 0 0 0 .528 2.31c.03.1.05.2.08.3l.002.008A8.42 8.42 0 0 1 3.99 8.058a.66.66 0 0 1-.204-.936L4.33 6.35c.204-.288.57-.383.897-.268a8.42 8.42 0 0 1 3.992 1.662 8.73 8.73 0 0 1 2.904 3.042c.08.16.08.34 0 .5l-.002.007a.61.61 0 0 1-.05.142c-.29.705-.54 1.42-.746 2.14-.16.57-.382 1.12-.61 1.64a.66.66 0 0 1-.21.27c-.204-.144-.48-.144-.684 0l-.438.308c-.204.144-.288.408-.216.648a10.34 10.34 0 0 0 .432 2.083z" fill="#FF7A59"/></svg>
                         <span class="text-sm font-medium text-gray-700">HubSpot</span>
                     </div>
+                    <!-- Salesforce -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Salesforce</title><path d="M11.354 0C8.873.027 5.164.224 3.42.493c-2.42.376-3.034 2.062-3.09 4.25-.11 3.96.005 8.015.005 8.015.012 2.448.72 4.143 3.09 4.477 1.75.271 9.166.47 11.647.498 2.48.027 6.19-.17 7.933-.44C25.443 21.42 26.06 19.73 26.11 17.54c.11-3.96-.004-8.015-.004-8.015C26.094 7.077 25.39 5.38 23 5.05c-1.74-.27-9.165-.472-11.646-.5zM9.703 16.63c-.323.562-1.01.96-1.643.96-.966 0-1.72-.73-1.72-1.81 0-1.01.69-1.84 1.81-1.84.37 0 .72.11 1.04.3.29.17.58.41.78.73.38.58.38 1.07.38 1.66zm3.59-2.89c-.55-.97-1.48-1.6-2.64-1.6-.3 0-.58.06-.84.16-.53.21-.98.6-1.32 1.1-.36.53-.56 1.16-.56 1.84 0 1.54 1.16 2.81 2.72 2.81 1.12 0 2.08-.66 2.53-1.63.22-.47.34-.99.34-1.54.03-.7-.26-1.28-.61-1.98zm4.19 2.92c-.324.562-1.01.96-1.644.96-.965 0-1.72-.73-1.72-1.81 0-1.01.69-1.84 1.81-1.84.375 0 .72.11 1.04.3.29.17.58.41.78.73.38.58.38 1.07.38 1.66zm3.73-2.71c-.55-.97-1.48-1.6-2.64-1.6-.3 0-.58.06-.84.16-.53.21-.98.6-1.32 1.1-.36.53-.56 1.16-.56 1.84 0 1.54 1.16 2.81 2.72 2.81 1.12 0 2.08-.66 2.53-1.63.22-.47.34-.99.34-1.54.03-.7-.26-1.28-.61-1.98z" fill="#00A1E0"/></svg>
                         <span class="text-sm font-medium text-gray-700">Salesforce</span>
                     </div>
+                    <!-- Pipedrive -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Pipedrive</title><path d="M19.958 0H4.037C1.808 0 0 1.807 0 4.037v15.922C0 22.192 1.808 24 4.037 24h15.921C22.192 24 24 22.192 24 19.959V4.037C24 1.808 22.192 0 19.958 0zM8.56 17.336a1.383 1.383 0 0 1-1.38 1.38H5.072a1.381 1.381 0 0 1-1.38-1.38V6.664c0-.76.62-1.38 1.38-1.38h2.108c.762 0 1.38.62 1.38 1.38v10.672zm4.498-2.652a1.38 1.38 0 0 1-1.38 1.38h-2.11a1.38 1.38 0 0 1-1.38-1.38V9.316c0-.762.62-1.38 1.38-1.38h2.11c.76 0 1.38.618 1.38 1.38v5.368zm4.496 4.012a1.38 1.38 0 0 1-1.38 1.38h-2.106a1.381 1.381 0 0 1-1.38-1.38V2.69c0-.762.618-1.38 1.38-1.38H16.17c.76 0 1.38.618 1.38 1.38v16.006z" fill="#2D8C22"/></svg>
                         <span class="text-sm font-medium text-gray-700">Pipedrive</span>
                     </div>
+                    <!-- Zoho CRM -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Zoho</title><path d="M1.608 16.32v-5.05L12 0l10.392 11.27v5.05L12 24zm2.802-3.19h5.76v-2.21h-5.76zm0-3.64h5.76v-2.21h-5.76zm0-3.64h5.76V3.64h-5.76zm7.62 10.47h5.76v-2.21h-5.76zm0-3.64h5.76v-2.21h-5.76zm0-3.64h5.76V7.28h-5.76zm0-3.64h5.76V3.64h-5.76z" fill="#EE3B2E"/></svg>
                         <span class="text-sm font-medium text-gray-700">Zoho CRM</span>
                     </div>
-                </div>
-                <p class="text-lg text-gray-700 font-semibold mt-10 mb-6 text-center">Outreach</p>
-                <div class="tech-logo-row" id="tech-logo-row-outreach" style="margin-top: 20px;">
+                    <!-- LinkedIn Sales Navigator -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>LinkedIn</title><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z" fill="#0A66C2"/></svg>
                         <span class="text-sm font-medium text-gray-700">LinkedIn Sales Navigator</span>
                     </div>
+                    <!-- Apollo.io -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <img src="https://www.vectorlogo.zone/logos/apolloio/apolloio-icon.svg" alt="Apollo.io" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Apollo.io</span>
                     </div>
+                    <!-- Lemlist -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Lemlist</title><path d="M22.466 12.009c0 6.632-5.38 12-12.008 12S0 18.584.013 12.009C.013 5.381 5.392.013 12.021.013c6.631 0 11.992 5.368 12.445 11.996zm-7.375-.71a2.711 2.711 0 00-2.708-2.713H8.93a2.711 2.711 0 00-2.708 2.713v1.422a2.711 2.711 0 002.708 2.712H12.4a2.711 2.711 0 002.709-2.712v-1.422zm-6.063 2.86c-.791 0-1.422-.643-1.422-1.422V9.942c0-.791.63-1.422 1.422-1.422h4.781c.792 0 1.422.631 1.422 1.422v2.925c0 .791-.63 1.422-1.422 1.422H9.028zm9.14-6.063a1.422 1.422 0 100-2.843 1.422 1.422 0 000 2.843z" fill="#F53D5C"/></svg>
                         <span class="text-sm font-medium text-gray-700">Lemlist</span>
                     </div>
+                    <!-- Mailshake -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <img src="https://asset.brandfetch.io/idobbS7jSp/idnmLGNLAL.svg" alt="Mailshake" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Mailshake</span>
                     </div>
+                </div>
+                <div class="tech-logo-row" id="tech-logo-row-2">
+                    <!-- Hunter.io -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <img src="https://asset.brandfetch.io/id1Y7bQdYx/id3jJ2JLzD.svg" alt="Hunter.io" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Hunter.io</span>
                     </div>
-                </div>
-                <p class="text-lg text-gray-700 font-semibold mt-10 mb-6 text-center">Scheduling</p>
-                <div class="tech-logo-row" id="tech-logo-row-scheduling" style="margin-top: 20px;">
+                    <!-- Calendly -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Calendly</title><path d="M19.655 14.262c.281 0 .557.023.828.064 0 .005-.005.01-.005.014-.105.267-.234.534-.381.786l-1.219 2.106c-1.112 1.936-3.177 3.127-5.411 3.127h-2.432c-2.23 0-4.294-1.191-5.412-3.127l-1.218-2.106a6.251 6.251 0 0 1 0-6.252l1.218-2.106C6.736 4.832 8.8 3.641 11.035 3.641h2.432c2.23 0 4.294 1.191 5.411 3.127l1.219 2.106c.147.252.271.519.381.786 0 .004.005.009.005.014-.267.041-.543.064-.828.064-1.816 0-2.501-.607-3.291-1.306-.764-.676-1.711-1.517-3.44-1.517h-1.029c-1.251 0-2.387.455-3.2 1.278-.796.805-1.233 1.904-1.233 3.099v1.411c0 1.196.437 2.295 1.233 3.099.813.823 1.949 1.278 3.2 1.278h1.034c1.729 0 2.676-.841 3.439-1.517.791-.703 1.471-1.306 3.287-1.301Zm.005-3.237c.399 0 .794-.036 1.179-.11-.002-.004-.002-.01-.002-.014-.073-.414-.193-.823-.349-1.218.731-.12 1.407-.396 1.986-.819 0-.004-.005-.013-.005-.018-.331-1.085-.832-2.101-1.489-3.03-.649-.915-1.435-1.719-2.331-2.395-1.867-1.398-4.088-2.138-6.428-2.138-1.448 0-2.855.28-4.175.841-1.273.543-2.423 1.315-3.407 2.299S2.878 6.552 2.341 7.83c-.557 1.324-.842 2.726-.842 4.175 0 1.448.281 2.855.842 4.174.542 1.274 1.314 2.423 2.298 3.407s2.129 1.761 3.407 2.299c1.324.556 2.727.841 4.175.841 2.34 0 4.561-.74 6.428-2.137a10.815 10.815 0 0 0 2.331-2.396c.652-.929 1.158-1.949 1.489-3.03 0-.004.005-.014.005-.018-.579-.423-1.255-.699-1.986-.819.161-.395.276-.804.349-1.218.005-.009.005-.014.005-.023.869.166 1.692.506 2.404 1.035.685.505.552 1.075.446 1.416C22.184 20.437 17.619 24 12.221 24c-6.625 0-12-5.375-12-12s5.37-12 12-12c5.398 0 9.963 3.563 11.471 8.464.106.341.239.915-.446 1.421-.717.529-1.535.873-2.404 1.034.128.716.128 1.45 0 2.166-.387-.074-.782-.11-1.182-.11-4.184 0-3.968 2.823-6.736 2.823h-1.029c-1.899 0-3.15-1.357-3.15-3.095v-1.411c0-1.738 1.251-3.094 3.15-3.094h1.034c2.768 0 2.552 2.823 6.731 2.827Z" fill="#006BFF"/></svg>
                         <span class="text-sm font-medium text-gray-700">Calendly</span>
                     </div>
+                    <!-- Google Calendar -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
-                        <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Google Calendar</title><path d="M20.66 3.74C18.54 1.61 15.47 0 12 0S5.46 1.61 3.34 3.74C1.21 5.86 0 8.93 0 12.34c0 1.7.41 3.34.91 4.81h22.18c.5-.98.91-2.62.91-4.31.02-3.41-1.19-6.48-3.34-8.6zm-8.66 17.8c-3.09 0-5.6-2.51-5.6-5.6s2.51-5.6 5.6-5.6 5.6 2.51 5.6 5.6-2.51 5.6-5.6 5.6zM10.5 9.5h3v5h-3z" fill="#4285F4"/></svg> <!-- Simplified path for example -->
+                        <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Google Calendar</title><path d="M20.66 3.74C18.54 1.61 15.47 0 12 0S5.46 1.61 3.34 3.74C1.21 5.86 0 8.93 0 12.34c0 1.7.41 3.34.91 4.81h22.18c.5-.98.91-2.62.91-4.31.02-3.41-1.19-6.48-3.34-8.6zm-8.66 17.8c-3.09 0-5.6-2.51-5.6-5.6s2.51-5.6 5.6-5.6 5.6 2.51 5.6 5.6-2.51 5.6-5.6 5.6zM10.5 9.5h3v5h-3z" fill="#4285F4"/></svg>
                         <span class="text-sm font-medium text-gray-700">Google Calendar</span>
                     </div>
+                    <!-- Notion -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Notion</title><path d="M22.53 6.704h-6.27V2.55S15.013.013 12.017.013C9.02.013 7.773 2.55 7.773 2.55v4.154H1.502V21.99h6.27V9.51h2.744v12.48h2.747V9.51h2.745v12.48h6.522V6.704zM9.02 2.55c0-.002.002-.002.004-.002h5.985s1.246-1.291 2.992-1.291c1.748 0 1.748 1.29 1.748 1.29v4.153h-6.27V2.55h-.002s0-1.291-1.496-1.291c-1.494 0-2.957 1.29-2.957 1.29z" fill="#000000"/></svg>
                         <span class="text-sm font-medium text-gray-700">Notion</span>
                     </div>
-                </div>
-                <p class="text-lg text-gray-700 font-semibold mt-10 mb-6 text-center">Reporting</p>
-                 <div class="tech-logo-row" id="tech-logo-row-reporting" style="margin-top: 20px;">
+                    <!-- Google Sheets -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Google Sheets</title><path d="M21.4 0H2.6C1.16 0 0 1.16 0 2.6v18.8C0 22.84 1.16 24 2.6 24h18.8c1.44 0 2.6-1.16 2.6-2.6V2.6C24 1.16 22.84 0 21.4 0zM8.45 19.6H4.9V17h3.55v2.6zm0-4.65H4.9v-2.6h3.55v2.6zm0-4.65H4.9V7.7h3.55v2.6zm5.85 9.3H10.1V17h4.2v2.6zm0-4.65H10.1v-2.6h4.2v2.6zm0-4.65H10.1V7.7h4.2v2.6zm5.85 9.3h-4.2V17h4.2v2.6zm0-4.65h-4.2v-2.6h4.2v2.6zm0-4.65h-4.2V7.7h4.2v2.6z" fill="#34A853"/></svg>
                         <span class="text-sm font-medium text-gray-700">Google Sheets</span>
                     </div>
+                    <!-- Microsoft Excel -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-2"><title>Microsoft Excel</title><path d="M23.36 1.36H.64A.64.64 0 000 2v20a.64.64 0 00.64.64h22.72a.64.64 0 00.64-.64V2a.64.64 0 00-.64-.64zM8.64 21.36H1.92V8.4h6.72v12.96zm7.04 0H9.28V8.4h6.4v12.96zm7.04 0h-6.4V8.4h6.4v12.96zM8.64 7.12H1.92V2.64h6.72v4.48zm7.04 0H9.28V2.64h6.4v4.48zm7.04 0h-6.4V2.64h6.4v4.48z" fill="#217346"/></svg>
                         <span class="text-sm font-medium text-gray-700">Excel</span>
                     </div>
+                    <!-- Airtable -->
                     <div class="tech-logo flex flex-col items-center justify-center p-4 bg-gray-50 rounded-lg hover:bg-white">
                         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/airtable/airtable-original.svg" alt="Airtable" class="h-16 w-16 mb-2">
                         <span class="text-sm font-medium text-gray-700">Airtable</span>
+                    </div>
+                </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- Removed category subheadings (CRM, Outreach, etc.) from the 'Our Technology Stack' section in Index.html.
- Consolidated all 15 technology logos into two main rows (8 logos in the first, 7 in the second) for a more condensed layout.
- Relies on existing flexbox styles for visual presentation and wrapping within these two rows.