### PR TITLE
Fix: Increase spacing between tech logos

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -771,7 +771,7 @@
 
               <!-- Single Row - Infinite Scroll -->
               <div class="logo-scroller" style="overflow: hidden; position: relative; height: 80px;">
-                <div class="logo-track" id="track1" style="display: flex; position: absolute; will-change: transform; gap: 24px; white-space: nowrap; left: 0;">
+                <div class="logo-track" id="track1" style="display: flex; position: absolute; will-change: transform; gap: 48px; white-space: nowrap; left: 0;">
                   <!-- CRM & Outreach Logos -->
                   <div class="tech-logo inline-flex items-center justify-center px-5 py-3 bg-gray-100 rounded-full whitespace-nowrap text-sm font-medium hover:bg-blue-50 transition-all duration-300">HubSpot</div>
                   <div class="tech-logo inline-flex items-center justify-center px-5 py-3 bg-gray-100 rounded-full whitespace-nowrap text-sm font-medium hover:bg-blue-50 transition-all duration-300">Salesforce</div>
@@ -791,7 +791,7 @@
                 </div>
 
                 <!-- Second Track for Seamless Loop -->
-                <div class="logo-track" id="track2" style="display: flex; position: absolute; will-change: transform; gap: 24px; white-space: nowrap; left: 100%;">
+                <div class="logo-track" id="track2" style="display: flex; position: absolute; will-change: transform; gap: 48px; white-space: nowrap; left: 100%;">
                   <!-- Same set again -->
                   <div class="tech-logo inline-flex items-center justify-center px-5 py-3 bg-gray-100 rounded-full whitespace-nowrap text-sm font-medium hover:bg-blue-50 transition-all duration-300">HubSpot</div>
                   <div class="tech-logo inline-flex items-center justify-center px-5 py-3 bg-gray-100 rounded-full whitespace-nowrap text-sm font-medium hover:bg-blue-50 transition-all duration-300">Salesforce</div>


### PR DESCRIPTION
Increased the gap from 24px to 48px in the inline styles for the logo scroller tracks to prevent them from appearing cramped.