### PR TITLE
Fix: Prevent horizontal overflow on contact page mobile view

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -22,6 +22,7 @@
     body {
       font-family: 'Poppins', sans-serif;
       scroll-behavior: smooth;
+      overflow-x: hidden; /* Prevent horizontal scrolling */
     }
 
     .hero-gradient {
@@ -252,7 +253,7 @@
         </div>
     </nav>
 
-    <div id="main-content-wrapper">
+    <div id="main-content-wrapper" style="overflow-x: hidden;">
     <main id="contact-page-content" class="min-h-[calc(100vh-380px)] md:min-h-[calc(100vh-340px)]">
         <section class="py-12 md:py-16 bg-blue-50 text-center">
             <div class="container mx-auto px-6">


### PR DESCRIPTION
Added `overflow-x: hidden;` to the body and main content wrapper to eliminate horizontal scrolling on smaller screens.