### PR TITLE
Fix: Embed map, verify mailto links, restore careers text

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -322,9 +322,8 @@
                 </div>
                  <div class="text-center mt-12" data-aos="fade-up">
                      <p class="text-gray-700">Don't see a role that fits? We're always looking for exceptional talent.</p>
-                     <p class="text-gray-700 mt-2">Contact our HR team at <a href="mailto:fiker@bridgeesolutions.com?subject=General%20Career%20Inquiry" class="text-blue-600 hover:underline">fiker@bridgeesolutions.com</a>.</p>
-                     <a href="mailto:fiker@bridgeesolutions.com?subject=General%20Career%20Inquiry" class="mt-4 inline-block px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold text-lg hover:bg-blue-700 transition duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">
-                        Email HR Team <i class="fas fa-paper-plane ml-2"></i>
+                     <a href="mailto:fiker@bridgeesolutions.com?subject=General%20Career%20Inquiry" class="mt-2 inline-block px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold text-lg hover:bg-blue-700 transition duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white focus:ring-offset-blue-600">
+                        Contact Our HR Team <i class="fas fa-paper-plane ml-2"></i>
                     </a>
                  </div>
             </div>

--- a/contact.html
+++ b/contact.html
@@ -305,11 +305,8 @@
                         </div>
                         <div class="bg-white p-8 rounded-xl shadow-lg">
                             <h3 class="text-xl font-bold text-gray-800 mb-4">Office Location</h3>
-                            <div class="h-64 rounded-lg">
-                                <a href="https://maps.app.goo.gl/eJN4DDtKzyGKz5ABA" target="_blank" rel="noopener noreferrer" class="block w-full h-full bg-gray-200 hover:bg-gray-300 transition-colors flex items-center justify-center text-blue-600 font-semibold rounded-lg">
-                                    View on Google Maps
-                                    <i class="fas fa-external-link-alt ml-2"></i>
-                                </a>
+                            <div class="h-64 rounded-lg overflow-hidden">
+                                <iframe src="https://www.google.com/maps/embed?pb=!1m17!1m12!1m3!1d3940.624459516806!2d38.786435999999995!3d9.00666!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m2!1m1!2zOcKwMDAnMjQuMCJOIDM4wrA0NycxMS4yIkU!5e0!3m2!1sen!2set!4v1751922462466!5m2!1sen!2set" width="100%" height="100%" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- Updated contact.html to use the provided iframe for an embedded Google Map.
- Verified the syntax of mailto: links for fiker@bridgeesolutions.com across relevant pages. The links appear structurally correct.
- Restored the text and button label in the careers.html HR contact section to their original state, while ensuring the button correctly links to mailto:fiker@bridgeesolutions.com with the appropriate subject line.