### PR TITLE
Feat: Implement 'Edit Blog Post' functionality in Admin Panel

### DIFF
--- a/templates/admin_blog_form.html
+++ b/templates/admin_blog_form.html
@@ -154,10 +154,14 @@
                     <div>
                         <label for="image_url">Image URL (Optional)</label>
                         <input type="url" name="image_url" id="image_url" value="{{ post.image_url if post and not post.image_url_is_static else '' }}" placeholder="https://example.com/image.jpg">
-                        {% if post and post.image_url and post.image_url_is_static %}
-                            <p class="text-xs text-gray-500 mt-1">Current static image: {{ post.image_url }}. Upload a new image or provide a URL to change.</p>
-                        {% elif post and post.image_url %}
-                             <p class="text-xs text-gray-500 mt-1">Current image URL. Upload an image or provide a new URL to change.</p>
+                        {% if post and post.image_url %}
+                            {% if post.image_url_is_static %}
+                                <p class="text-xs text-gray-500 mt-1">Current static image:</p>
+                                <img src="{{ post.image_url }}" alt="Current image for {{ post.title | escape }}" class="my-2 max-w-xs h-auto rounded border shadow-sm">
+                                <p class="text-xs text-gray-500 mt-1">Path: {{ post.image_url }}. Upload a new image or provide a URL to change/remove (leave URL blank to remove).</p>
+                            {% else %}
+                                 <p class="text-xs text-gray-500 mt-1">Current image URL: <a href="{{ post.image_url }}" target="_blank" class="text-blue-500 hover:underline">{{ post.image_url }}</a>. Upload an image or provide a new URL to change/remove (leave URL blank to remove).</p>
+                            {% endif %}
                         {% endif %}
                     </div>
                      <p class="text-center text-sm font-medium text-gray-500 my-2">OR</p>

--- a/templates/admin_blog_list.html
+++ b/templates/admin_blog_list.html
@@ -85,9 +85,9 @@
                                 </span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                                <a href="#" class="text-indigo-600 hover:text-indigo-900 mr-3">Edit</a>
+                                <a href="{{ url_for('admin_edit_blog_post', post_id=post.id) }}" class="text-indigo-600 hover:text-indigo-900 mr-3">Edit</a>
                                 <a href="#" class="text-red-600 hover:text-red-900">Delete</a>
-                                <!-- TODO: Implement actual edit/delete links/functionality -->
+                                <!-- TODO: Implement actual delete link/functionality -->
                             </td>
                         </tr>
                         {% endfor %}


### PR DESCRIPTION
- I created the `/admin/blog/edit/<post_id>` route in `app.py`.
  - GET requests load the specified post and render `admin_blog_form.html` pre-filled with post data.
  - POST requests process submitted changes for title, author, content (text, file, .docx with conversion), and image (URL or upload).
  - I handled replacement of content and images, including deletion of old static images when updated or removed.
  - I updated the corresponding entry in `blog_posts.json`.
  - I included validation for required fields and provided you with feedback via flashed messages.
- I updated 'Edit' links in `admin_blog_list.html` to point to the new edit route.
- I enhanced `admin_blog_form.html` to better display existing image information during editing.