### PR TITLE
Feat: Implement delete blog post functionality

### DIFF
--- a/templates/admin_blog_list.html
+++ b/templates/admin_blog_list.html
@@ -86,8 +86,7 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                                 <a href="{{ url_for('admin_edit_blog_post', post_id=post.id) }}" class="text-indigo-600 hover:text-indigo-900 mr-3">Edit</a>
-                                <a href="#" class="text-red-600 hover:text-red-900">Delete</a>
-                                <!-- TODO: Implement actual delete link/functionality -->
+                                <a href="{{ url_for('admin_delete_blog_post', post_id=post.id) }}" class="text-red-600 hover:text-red-900" onclick="return confirm('Are you sure you want to delete this post?');">Delete</a>
                             </td>
                         </tr>
                         {% endfor %}
@@ -95,8 +94,7 @@
                 </table>
             </div>
             {% else %}
-            <p class="text-gray-600 text-center py-4">No blog posts found. <a href="#" class="text-blue-600 hover:underline">Create the first one!</a></p>
-            <!-- TODO: Link to actual create post route later -->
+            <p class="text-gray-600 text-center py-4">No blog posts found. <a href="{{ url_for('admin_create_blog_post') }}" class="text-blue-600 hover:underline">Create the first one!</a></p>
             {% endif %}
         </div>
     </main>


### PR DESCRIPTION
- Added /admin/blog/delete/<post_id> route to handle post deletion.
- Implemented logic to remove the post from blog_posts.json.
- Added functionality to delete associated static uploaded images from the static/uploaded_images/ folder when a post is deleted.
- Updated admin_blog_list.html to include correct delete links with a JavaScript confirmation dialog.
- Included error handling and flash messages for the deletion process.