### PR TITLE
Feat: Implement HR application status updates

### DIFF
--- a/templates/admin_hr_application_detail.html
+++ b/templates/admin_hr_application_detail.html
@@ -132,12 +132,33 @@
                 </div>
                 {% endif %}
 
-                <!-- Placeholder for future status change form -->
+                <!-- Status Update Form -->
                 <div class="mt-6 pt-4 border-t border-gray-200">
-                    <h3 class="text-lg font-medium text-gray-700 mb-2">Update Status (Future)</h3>
-                    <p class="text-sm text-gray-500">Functionality to update application status will be here.</p>
-                </div>
+                    <h3 class="text-lg font-medium text-gray-700 mb-3">Update Application Status</h3>
+                    {% set current_status = application.status %}
+                    {% set app_id = application.cv_filename.split('-', 1)[0] %}
+                    {% set possible_next_statuses = valid_status_transitions.get(current_status, []) %}
 
+                    {% if possible_next_statuses %}
+                        <form method="POST" action="{{ url_for('admin_hr_update_application_status', app_id=app_id) }}" class="space-y-3">
+                            <div>
+                                <label for="new_status" class="block text-sm font-medium text-gray-700">Change status to:</label>
+                                <select id="new_status" name="new_status" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                    {% for status_key in possible_next_statuses %}
+                                        <option value="{{ status_key }}">{{ status_display_names.get(status_key, status_key.replace('_', ' ') | title) }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div>
+                                <button type="submit" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                    Update Status
+                                </button>
+                            </div>
+                        </form>
+                    {% else %}
+                        <p class="text-sm text-gray-500">No further status transitions available from '{{ status_display_names.get(current_status, current_status) }}'.</p>
+                    {% endif %}
+                </div>
             </div>
             {% else %}
                 <p class="text-red-600">Application details could not be loaded.</p>


### PR DESCRIPTION
- Added functionality to update the status of job applications.
- Defined status display names and valid transition rules in app.py.
- Modified the application detail template to include a form for selecting and submitting a new status.
- Created a new route in app.py to handle status update logic, including validation, data persistence, and audit field updates (reviewed_timestamp, reviewed_by, reviewed_by_name).
- Added a save_applications_hr helper function.