### PR TITLE
Feat: Add statistics to admin dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -885,10 +885,37 @@ def admin_edit_blog_post(post_id):
     # GET request
     return render_template('admin_blog_form.html', title=f"Edit Post: {post_to_edit.get('title')}", post=post_to_edit, now=datetime.utcnow())
 
+from collections import Counter # Import Counter for status breakdown
+
 @app.route('/admin/dashboard')
 @login_required
 def admin_dashboard():
-    return render_template('admin_dashboard.html', title="Admin Dashboard", now=datetime.utcnow())
+    # Blog statistics
+    blog_posts = load_blog_posts()
+    total_blog_posts = len(blog_posts)
+
+    # HR statistics
+    hr_applications = load_applications_hr()
+    total_hr_applications = len(hr_applications)
+
+    hr_applications_by_status = {}
+    if hr_applications:
+        status_counts = Counter(app_item.get('status', 'unknown') for app_item in hr_applications)
+        # Ensure all statuses from STATUS_DISPLAY_NAMES_HR are present, even if count is 0
+        for status_key in STATUS_DISPLAY_NAMES_HR:
+            hr_applications_by_status[status_key] = status_counts.get(status_key, 0)
+    else: # Ensure structure exists even if no applications
+        for status_key in STATUS_DISPLAY_NAMES_HR:
+            hr_applications_by_status[status_key] = 0
+
+
+    return render_template('admin_dashboard.html',
+                           title="Admin Dashboard",
+                           now=datetime.utcnow(),
+                           total_blog_posts=total_blog_posts,
+                           total_hr_applications=total_hr_applications,
+                           hr_applications_by_status=hr_applications_by_status,
+                           status_display_names_hr=STATUS_DISPLAY_NAMES_HR) # Pass for display
 
 @app.route('/admin/blog/delete/<string:post_id>', methods=['GET']) # Using GET for simplicity, ideally POST with CSRF
 @login_required

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -72,6 +72,35 @@
             {% endif %}
         </div>
 
+        <!-- Statistics Section -->
+        <div class="mb-8 grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="dashboard-card text-center">
+                <h3 class="text-lg font-semibold text-gray-700">Total Blog Posts</h3>
+                <p class="text-4xl font-bold text-indigo-600">{{ total_blog_posts | default('N/A') }}</p>
+            </div>
+            <div class="dashboard-card text-center">
+                <h3 class="text-lg font-semibold text-gray-700">Total HR Applications</h3>
+                <p class="text-4xl font-bold text-teal-600">{{ total_hr_applications | default('N/A') }}</p>
+            </div>
+            <div class="dashboard-card">
+                <h3 class="text-lg font-semibold text-gray-700 mb-2 text-center md:text-left">HR Applications by Status</h3>
+                {% if hr_applications_by_status %}
+                    <ul class="space-y-1 text-sm">
+                        {% for status_key, count in hr_applications_by_status.items() %}
+                            <li class="flex justify-between">
+                                <span>{{ status_display_names_hr.get(status_key, status_key.replace('_',' ')|title) }}:</span>
+                                <span class="font-semibold">{{ count }}</span>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="text-sm text-gray-500 text-center md:text-left">No application data available.</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <hr class="my-8">
+
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <!-- Blog Management Card -->
             <div class="dashboard-card">


### PR DESCRIPTION
- Updated the admin_dashboard route to calculate and pass statistics:
  - Total number of blog posts.
  - Total number of HR applications.
  - Breakdown of HR applications by status.
- Modified admin_dashboard.html to display these statistics in a new section.
- Used collections.Counter for efficient status counting.
- Ensured all defined statuses are displayed in the breakdown, even with zero counts.